### PR TITLE
fix: remove spotify client and client secret from binary

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -41,8 +41,6 @@ jobs:
         env:
           CGO_ENABLED: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
-          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v5

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,8 +13,6 @@ builds:
     main: .
     ldflags:
       - -s -w -X main.version={{ .Version }}
-      - -X main.spotifyClientID={{ .Env.SPOTIFY_CLIENT_ID }}
-      - -X main.spotifyClientSecret={{ .Env.SPOTIFY_CLIENT_SECRET }}
     env:
       - CGO_ENABLED=1
     goos:

--- a/Makefile
+++ b/Makefile
@@ -7,36 +7,33 @@ help: ## list makefile targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: build
-build: ## build golang binary with embedded JS backend
+build: 
 	@echo "--> Building Go application..."
-	@go build -ldflags "-X main.version=$(shell git describe --abbrev=0 --tags) -X main.spotifyClientID=$(SPOTIFY_CLIENT_ID) -X main.spotifyClientSecret=$(SPOTIFY_CLIENT_SECRET)" -o $(projectname)
+	@go build -ldflags "-X main.version=$(shell git describe --abbrev=0 --tags)" -o $(projectname)
 
 .PHONY: install
-install: build ## install binary to /usr/local/bin
+install: build
 	@echo "--> Installing clispot to /usr/local/bin..."
 	@sudo cp $(projectname) /usr/local/bin/
 	@echo "--> Installation complete. Run 'clispot' to start."
 
 .PHONY: run
-run: build ## build and run the app
+run: build 
 	@./$(projectname)
 
 .PHONY: bootstrap
-bootstrap: ## install build deps
+bootstrap: 
 	go generate -tags tools tools/tools.go
 
 .PHONY: test
-test: clean ## display test coverage
+test: clean 
 	go test --cover -parallel=1 -v -coverprofile=coverage.out ./...
 	go tool cover -func=coverage.out | sort -rnk3
 
 .PHONY: clean
-clean: ## clean up environment
+clean: 
 	@echo "--> Cleaning up..."
 	@rm -rf coverage.out dist/ $(projectname)
-	@rm -rf embed
-	@rm -rf js/bin
-	@rm -rf js/node_modules
 
 .PHONY: cover
 cover: ## display test coverage

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -78,13 +78,15 @@ For other operating systems, please build from source (see [Building from Source
 
 ### Authentication
 
+Before you can authenticate, you need to set up your Spotify API credentials. For detailed instructions on how to do this, please see the [Building from Source](install.md).
+
 On first run, clispot will:
 1. Start a local web server on port 9292
 2. Open your default browser to Spotify's authorization page
 3. Ask you to authorize the application
 4. Save the authentication token to `~/.clispot/token.json`
 
-The token is automatically refreshed when needed. You only need to authenticate once (unless you revoke access in Spotify settings).
+The token is automatically refreshed when needed. You only need to authenticate once (unless you revoke it).
 
 ## Usage
 
@@ -220,12 +222,6 @@ clispot uses a three-panel layout:
 
 ### Common Issues
 
-**"yt-dlp not found"**
-* Install `yt-dlp` using your package manager (see Prerequisites)
-
-**"ffmpeg not found"**
-* Install `ffmpeg` using your package manager
-
 **Music doesn't play**
 * Check that `yt-dlp` and `ffmpeg` are installed and in your PATH
 * Verify your internet connection
@@ -236,9 +232,6 @@ clispot uses a three-panel layout:
 **Authentication fails**
 * Ensure port 9292 is not blocked by a firewall
 * Check that your browser can open automatically (or manually open the URL shown)
-
-**Token expired errors**
-* Delete `~/.clispot/token.json` and re-authenticate
 
 ## Technical Details
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,23 +10,34 @@ Before building clispot from source, ensure you have the following prerequisites
 ## Installation Steps
 
 1. Clone the repository:
+
    ```bash
    git clone https://github.com/kumneger0/clispot.git
    cd clispot
    ```
 
 2. Create a Spotify Application:
-   - Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/applications).
-   - Log in with your Spotify account.
-   - Click on "Create an app" and fill in the required details.
-   - Once the app is created, navigate to "Settings".
-   - Under "Redirect URIs", add `http://127.0.0.1:9292`. This is the redirect URI used by clispot for authentication.
-   - Save the changes.
-   - Note down your `Client ID` and `Client Secret`.
+
+   1. Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/applications) and log in.
+   2. Click on **"Create an app"**.
+   3. Give your application a name and description.
+   4. Find the **"Redirect URIs"** section and add the following URI:
+      ```
+      http://127.0.0.1:9292
+      ```
+   5. Save your changes.
+   6. Now, view your application's settings and find your **Client ID** and **Client Secret**.
+   7. Set them as environment variables. For example, you can add the following lines to your shell's configuration file (e.g., `.bashrc`, `.zshrc`):
+      ```bash
+      export SPOTIFY_CLIENT_ID="<your-client-id>"
+      export SPOTIFY_CLIENT_SECRET="<your-client-secret>"
+      ```
+   8. Remember to replace `<your-client-id>` and `<your-client-secret>` with the actual credentials from your Spotify application.
 
 3. Build the project with your Spotify credentials:
+
    ```bash
-   go build -ldflags="-X main.spotifyClientID=<your-client-id> -X main.spotifyClientSecret=<your-client-secret>" main.go
+   make build
    ```
 
 If you encounter any issues during installation:  

--- a/internal/spotify/authenticate.go
+++ b/internal/spotify/authenticate.go
@@ -35,7 +35,7 @@ type Secret struct {
 }
 
 func getSecret() (*Secret, error) {
-	clientID, found := os.LookupEnv("SPOTIFY_ClIENT_ID")
+	clientID, found := os.LookupEnv("SPOTIFY_CLIENT_ID")
 	if !found {
 		return nil, errors.New("no client id found")
 	}

--- a/internal/types/search.go
+++ b/internal/types/search.go
@@ -1,4 +1,4 @@
-package types
+package types // nolint:revive
 
 type Restrictions struct {
 	Reason string `json:"reason"`

--- a/main.go
+++ b/main.go
@@ -13,9 +13,7 @@ import (
 )
 
 var (
-	version             = ""
-	spotifyClientID     = ""
-	spotifyClientSecret = ""
+	version = ""
 )
 
 func main() {
@@ -41,7 +39,7 @@ func main() {
 	if err := os.WriteFile(lockFilePath, []byte(strconv.Itoa(pid)), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not write PID to lock file: %v\n", err)
 	}
-	err = cmd.Execute(version, spotifyClientID, spotifyClientSecret)
+	err = cmd.Execute(version)
 	if err != nil {
 		slog.Error(err.Error())
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Authentication simplified to use locally-provided client credentials (from the environment) rather than passing them through command/setup parameters.

* **Documentation**
  * Installation and authentication guidance updated with clearer, step-by-step Spotify setup and build instructions; troubleshooting and token wording adjusted.

* **Chores**
  * Build/release steps and CI workflow cleaned to stop embedding credentials into builds and reduce exposed environment in release jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->