### PR TITLE
fix: ensure that the player section is focused before chaning music

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -173,8 +173,8 @@ clispot uses a three-panel layout:
 
 **Playback Controls:**
 * `Space` - Toggle play/pause
-* `n` - Play next track in queue
-* `b` - Play previous track in queue
+* `n` - Play next track in queue(the player section needs to be focused here)
+* `b` - Play previous track in queue(the player section needs to be focused here)
 
 **Exiting:**
 * `q` or `Ctrl+C` - Quit the application

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -234,8 +234,14 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case " ":
 		return m.handleMusicPausePlay()
 	case "b":
+		if m.FocusedOn != Player {
+			return m, nil
+		}
 		return m.handleMusicChange(false)
 	case "n":
+		if m.FocusedOn != Player {
+			return m, nil
+		}
 		return m.handleMusicChange(true)
 	case "q", "ctrl+c":
 		if m.PlayerProcess != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified keyboard shortcuts: “n” and “b” now note the player must be focused to navigate the queue.

* **Bug Fixes**
  * Playback navigation via “n”/“b” only triggers when the player is focused, preventing these keys from affecting the queue while other UI areas are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->