### PR TITLE
fix: unexpected pause when typing on search bar

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -241,6 +241,9 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 			return m, cmd
 		}
 	case " ":
+		if m.FocusedOn != Player {
+			return m, nil
+		}
 		return m.handleMusicPausePlay()
 	case "b":
 		if m.FocusedOn != Player {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Spacebar now only controls music playback when the player is in focus. This prevents accidental playback control when interacting with other elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->