### PR TITLE
feat: allow user to pass --cookies-from-browser flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,7 +85,7 @@ func runRoot(cmd *cobra.Command) error {
 	}
 
 	if cookiesFromBrowser != "" {
-		ytDlpArgs.CookiesFromBrowser = (*config.Browser)(&cookiesFromBrowser)
+		ytDlpArgs.CookiesFromBrowser = (&cookiesFromBrowser)
 	}
 
 	cookiesFile, err := cmd.Flags().GetString("cookies")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,9 +73,35 @@ func runRoot(cmd *cobra.Command) error {
 		os.Exit(1)
 	}
 
+	ytDlpArgs := config.YtDlpArgs{
+		CookiesFromBrowser: nil,
+		Cookies:            nil,
+	}
+
+	cookiesFromBrowser, err := cmd.Flags().GetString("cookies-from-browser")
+
+	if err != nil {
+		slog.Error(err.Error())
+	}
+
+	if cookiesFromBrowser != "" {
+		ytDlpArgs.CookiesFromBrowser = (*config.Browser)(&cookiesFromBrowser)
+	}
+
+	cookiesFile, err := cmd.Flags().GetString("cookies")
+
+	if err != nil {
+		slog.Error(err.Error())
+	}
+
+	if cookiesFile != "" {
+		ytDlpArgs.Cookies = &cookiesFile
+	}
+
 	config.SetConfig(&config.Config{
 		DebugDir:      debugDir,
 		CacheDisabled: isCacheDisabled,
+		YtDlpArgs:     &ytDlpArgs,
 	})
 
 	logger := logSetup.Init(debugDir)
@@ -232,6 +258,8 @@ func Execute(version string) error {
 	defaultDebugDir := filepath.Join(userHomeDir, ".clispot", "logs")
 	cmd.Flags().StringP("debug-dir", "d", defaultDebugDir, "a path to store app logs")
 	cmd.Flags().Bool("disable-cache", false, "disable cache")
+	cmd.Flags().String("cookies-from-browser", "", "The name of the browser to load cookies from this option is used by yt-dlp see yt-dlp docs to see supported browsers")
+	cmd.Flags().String("cookies", "", "cookies file the option you pass for this flag will be passed to yt-dlp checkout yt-dlp docs to learn more about this flag")
 	if err := cmd.Execute(); err != nil {
 		return fmt.Errorf("error executing root command: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,21 +1,7 @@
 package config
 
-type Browser string
-
-const (
-	CHROME   Browser = "chrome"
-	CHROMIUM Browser = "chromium"
-	FIREFOX  Browser = "firefox"
-	BRAVE    Browser = "brave"
-	EDGE     Browser = "edge"
-	OPERA    Browser = "opera"
-	SAFARI   Browser = "safari"
-	VIVALDI  Browser = "vivaldi"
-	WHALE    Browser = "whale"
-)
-
 type YtDlpArgs struct {
-	CookiesFromBrowser *Browser
+	CookiesFromBrowser *string
 	Cookies            *string
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,13 +3,20 @@ package config
 type Browser string
 
 const (
-	CHROME  Browser = "chrome"
-	FIREFOX Browser = "firefox"
-	BRAVE   Browser = "brave"
+	CHROME   Browser = "chrome"
+	CHROMIUM Browser = "chromium"
+	FIREFOX  Browser = "firefox"
+	BRAVE    Browser = "brave"
+	EDGE     Browser = "edge"
+	OPERA    Browser = "opera"
+	SAFARI   Browser = "safari"
+	VIVALDI  Browser = "vivaldi"
+	WHALE    Browser = "whale"
 )
 
 type YtDlpArgs struct {
-	CookiesFromBrowser Browser
+	CookiesFromBrowser *Browser
+	Cookies            *string
 }
 
 type Config struct {

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -85,7 +85,7 @@ func SearchAndDownloadMusic(
 	}
 
 	if appConfig.YtDlpArgs.CookiesFromBrowser != nil {
-		args = append(args, "--cookies-from-browser", string(*appConfig.YtDlpArgs.CookiesFromBrowser))
+		args = append(args, "--cookies-from-browser", *appConfig.YtDlpArgs.CookiesFromBrowser)
 	}
 	if appConfig.YtDlpArgs.Cookies != nil {
 		args = append(args, "--cookies", *appConfig.YtDlpArgs.Cookies)

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -77,6 +77,20 @@ func SearchAndDownloadMusic(
 
 	appConfig := config.GetConfig()
 
+	args := []string{
+		searchQuery,
+		"--no-playlist",
+		"-f", "bestaudio",
+		"-o", "-",
+	}
+
+	if appConfig.YtDlpArgs.CookiesFromBrowser != nil {
+		args = append(args, "--cookies-from-browser", string(*appConfig.YtDlpArgs.CookiesFromBrowser))
+	}
+	if appConfig.YtDlpArgs.Cookies != nil {
+		args = append(args, "--cookies", *appConfig.YtDlpArgs.Cookies)
+	}
+
 	logPathName := appConfig.DebugDir
 
 	ytStderr, _ := os.Create(filepath.Join(logPathName, "ytstderr.log"))
@@ -86,12 +100,7 @@ func SearchAndDownloadMusic(
 		return playExistingMusic(musicPath, shouldWait, ffStderr, ytStderr)
 	}
 
-	yt := exec.Command("yt-dlp",
-		searchQuery,
-		"--no-playlist",
-		"-f", "bestaudio",
-		"-o", "-",
-	)
+	yt := exec.Command("yt-dlp", args...)
 	yt.Stderr = ytStderr
 
 	ytOut, err := yt.StdoutPipe()


### PR DESCRIPTION
this option will be used by yt-dlp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cookie-based authentication for downloads via two new flags: --cookies-from-browser (extract cookies from a browser) and --cookies (provide cookies manually)

* **Updated**
  * Broader browser support for cookie extraction (Chromium, Edge, Opera, Safari, Vivaldi, Whale)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->