### PR TITLE
docs: explain clispot-lyrics binary renaming

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -58,7 +58,7 @@
   * Caches YouTube audio streams for played tracks so next time when you play same song it plays from cache.
 
 * **Lyrics Display**
-  * View lyrics for the currently playing music. To enable this feature, install the `clispot-lyrics` tool globally from [https://github.com/Kumneger0/clispot-lyrics](https://github.com/Kumneger0/clispot-lyrics). Once installed, clispot will automatically provide an option to open lyrics for the selected music.
+  * View lyrics for the currently playing music. To enable this feature, install the `clispot-lyrics` tool globally from [https://github.com/Kumneger0/clispot-lyrics](https://github.com/Kumneger0/clispot-lyrics). Note that the downloaded binary might have a suffix indicating the OS and CPU architecture (e.g., `clispot-lyrics-linux-aarch64`). You must rename this binary to `clispot-lyrics` for clispot to correctly detect it. Once installed, clispot will automatically provide an option to open lyrics for the selected music.
 
 ### Technical Details
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for the Lyrics Display feature, clarifying that downloaded clispot-lyrics binaries may include OS/CPU-specific suffixes (e.g., clispot-lyrics-linux-aarch64) and must be renamed to clispot-lyrics for proper system recognition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->