### PR TITLE
feat: implement music queue management in headless mode with D-Bus control

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -203,7 +203,7 @@ func runRoot(cmd *cobra.Command) error {
 		slog.Error(err.Error())
 	}
 
-	ins, messageChan, err := mpris.GetDbusInstance(isHeadlessMode)
+	ins, messageChan, err := mpris.GetDbusInstance()
 
 	if err != nil {
 		slog.Error(err.Error())

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -51,6 +51,9 @@ func (h *Queue) AddTrack(track *types.PlaylistTrackObject) {
 }
 
 func (h *Queue) RemoveTrack(index int) {
+	if index < 0 || index >= len(h.Tracks) {
+		return
+	}
 	h.Tracks = append(h.Tracks[:index], h.Tracks[index+1:]...)
 }
 

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/kumneger0/clispot/internal/types"
@@ -66,11 +67,14 @@ func NewMusicQueue() *Queue {
 
 func StartServer(m *ui.SafeModel, dbusMessageChan *chan types.DBusMessage) {
 	musicQueue := NewMusicQueue()
+	var mqMu sync.Mutex
+
 	go func() {
 		if dbusMessageChan == nil {
 			return
 		}
 		for msg := range *dbusMessageChan {
+			mqMu.Lock()
 			switch msg.MessageType {
 			case types.NextTrack:
 				if len(musicQueue.Tracks) == 0 {
@@ -107,6 +111,7 @@ func StartServer(m *ui.SafeModel, dbusMessageChan *chan types.DBusMessage) {
 					m.Model = &model
 				}
 			}
+			mqMu.Unlock()
 		}
 	}()
 

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -93,6 +93,9 @@ func StartServer(m *ui.SafeModel, dbusMessageChan *chan types.DBusMessage) {
 				model, _ := m.HandleMusicPausePlay()
 				m.Model = &model
 			case types.PreviousTrack:
+				if len(musicQueue.Tracks) == 0 {
+					continue
+				}
 				prevTrackIndex := musicQueue.CurrentIndex - 1
 				if prevTrackIndex < 0 {
 					prevTrackIndex = len(musicQueue.Tracks) - 1

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -73,6 +73,9 @@ func StartServer(m *ui.SafeModel, dbusMessageChan *chan types.DBusMessage) {
 		for msg := range *dbusMessageChan {
 			switch msg.MessageType {
 			case types.NextTrack:
+				if len(musicQueue.Tracks) == 0 {
+					continue
+				}
 				nextTrackIndex := musicQueue.CurrentIndex + 1
 				if nextTrackIndex >= len(musicQueue.Tracks) {
 					nextTrackIndex = 0

--- a/internal/mpris/mpris.go
+++ b/internal/mpris/mpris.go
@@ -11,7 +11,7 @@ import (
 	"github.com/kumneger0/clispot/internal/ui"
 )
 
-func newProp(value interface{}, cb func(*prop.Change) *dbus.Error) *prop.Prop {
+func newProp(value any, cb func(*prop.Change) *dbus.Error) *prop.Prop {
 	return &prop.Prop{
 		Value:    value,
 		Writable: true,
@@ -20,7 +20,7 @@ func newProp(value interface{}, cb func(*prop.Change) *dbus.Error) *prop.Prop {
 	}
 }
 
-func getPlayer(headless bool) map[string]*prop.Prop {
+func getPlayer() map[string]*prop.Prop {
 	return map[string]*prop.Prop{
 		"PlaybackStatus": newProp("paused", nil),
 		"Rate":           newProp(1.0, nil),
@@ -29,8 +29,8 @@ func getPlayer(headless bool) map[string]*prop.Prop {
 		"Position":       newProp(int64(0), nil),
 		"MinimumRate":    newProp(1.0, nil),
 		"MaximumRate":    newProp(1.0, nil),
-		"CanGoNext":      newProp(!headless, nil),
-		"CanGoPrevious":  newProp(!headless, nil),
+		"CanGoNext":      newProp(true, nil),
+		"CanGoPrevious":  newProp(true, nil),
 		"CanPlay":        newProp(true, nil),
 		"CanPause":       newProp(true, nil),
 		"CanSeek":        newProp(false, nil),
@@ -80,7 +80,7 @@ func (m *MediaPlayer2) PlayPause() *dbus.Error {
 	return nil
 }
 
-func GetDbusInstance(headless bool) (*ui.Instance, *chan types.DBusMessage, error) {
+func GetDbusInstance() (*ui.Instance, *chan types.DBusMessage, error) {
 	if runtime.GOOS != "linux" {
 		return nil, nil, nil
 	}
@@ -108,7 +108,7 @@ func GetDbusInstance(headless bool) (*ui.Instance, *chan types.DBusMessage, erro
 		"/org/mpris/MediaPlayer2",
 		map[string]map[string]*prop.Prop{
 			"org.mpris.MediaPlayer2":        mediaPlayer2,
-			"org.mpris.MediaPlayer2.Player": getPlayer(headless),
+			"org.mpris.MediaPlayer2.Player": getPlayer(),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Music queue management: add/remove tracks and pre-populate queues
  * Track navigation controls update queue position and playback state
  * Event streaming now includes current track index alongside playback time

* **Behavior Changes**
  * Player navigation controls are now consistently reported as available, enabling next/previous actions more predictably

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->