### PR TITLE
fix: pause currently playing track before fetching next track metadata

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -452,14 +452,17 @@ func StartServer(m *ui.SafeModel, dbusMessageChan *chan types.DBusMessage) {
 			return
 		}
 
-		if reqBody.Queue != nil {
-			musicQueue = reqBody.Queue
-		}
-
 		userToken := m.GetUserToken()
 		if userToken == nil {
 			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 			return
+		}
+
+		model, _ := m.HandleMusicPausePlay()
+		m.Model = &model
+
+		if reqBody.Queue != nil {
+			musicQueue = reqBody.Queue
 		}
 
 		track, err := m.SpotifyClient.GetTrack(reqBody.TrackID, userToken.AccessToken)
@@ -475,7 +478,7 @@ func StartServer(m *ui.SafeModel, dbusMessageChan *chan types.DBusMessage) {
 			return
 		}
 
-		model, _ := m.PlaySelectedMusic(types.PlaylistTrackObject{
+		model, _ = m.PlaySelectedMusic(types.PlaylistTrackObject{
 			Track:   *track,
 			AddedAt: "",
 			AddedBy: nil,

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -425,6 +425,9 @@ func (m Model) HandleMusicPausePlay() (Model, tea.Cmd) {
 	if m.PlayerProcess == nil {
 		return m, nil
 	}
+	if m.PlayerProcess.OtoPlayer == nil {
+		return m, nil
+	}
 	if m.PlayerProcess.OtoPlayer.IsPlaying() {
 		m.PlayerProcess.OtoPlayer.Pause()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against potential crashes when player initialization is incomplete.
  * Improved playback state synchronization to ensure pause/play controls work reliably with queue operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->