### PR TITLE
feat: implement queue management with new API endpoints for adding an

### DIFF
--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -525,14 +525,16 @@ func StartServer(m *ui.SafeModel, dbusMessageChan *chan types.DBusMessage) {
 	})
 
 	mux.HandleFunc("GET /player/queue", func(w http.ResponseWriter, r *http.Request) {
+		mqMu.Lock()
+		defer mqMu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
 		data, err := json.Marshal(musicQueue)
 		if err != nil {
 			slog.Error(err.Error())
 			http.Error(w, `{"message":"failed to encode response", status:"error"}`, http.StatusBadRequest)
 			return
 		}
+		w.WriteHeader(http.StatusOK)
 		_, err = w.Write(data)
 		if err != nil {
 			slog.Error(err.Error())

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -54,6 +54,9 @@ type Queue struct {
 }
 
 func (h *Queue) AddTrack(track *types.PlaylistTrackObject, index int) {
+	if index < 0 || index > len(h.Tracks) {
+		index = len(h.Tracks)
+	}
 	h.Tracks = append(h.Tracks[:index], append([]*types.PlaylistTrackObject{track}, h.Tracks[index:]...)...)
 }
 

--- a/internal/headless/headless.go
+++ b/internal/headless/headless.go
@@ -542,6 +542,8 @@ func StartServer(m *ui.SafeModel, dbusMessageChan *chan types.DBusMessage) {
 	})
 
 	mux.HandleFunc("POST /player/queue/add", func(w http.ResponseWriter, r *http.Request) {
+		mqMu.Lock()
+		defer mqMu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 		var reqBody AddTrackToQueue
 		err := json.NewDecoder(r.Body).Decode(&reqBody)

--- a/internal/types/playlist.go
+++ b/internal/types/playlist.go
@@ -57,10 +57,11 @@ type PlaylistItemsResponse struct {
 }
 
 type PlaylistTrackObject struct {
-	AddedAt string       `json:"added_at"`
-	AddedBy *SpotifyUser `json:"added_by"`
-	IsLocal bool         `json:"is_local"`
-	Track   Track        `json:"track"`
+	AddedAt       string       `json:"added_at"`
+	AddedBy       *SpotifyUser `json:"added_by"`
+	IsLocal       bool         `json:"is_local"`
+	Track         Track        `json:"track"`
+	IsItFromQueue bool         `json:"isItFromQueue"`
 }
 
 func (playlist PlaylistTrackObject) FilterValue() string {


### PR DESCRIPTION
          and removing tracks at specific indices
add  field to playlist track objects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added queue management endpoints: view queue, add tracks at specific positions, and remove tracks.
  * Track insertion now supports position-based control and maintains correct current index.

* **Bug Fixes**
  * Fixed duplicate variable issue in playback handling.
  * Improved safety when removing tracks from the queue.
  * Root endpoint now returns JSON with proper content type.

* **Refactor**
  * Added track metadata to mark queue origin and improved queue state handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->