### PR TITLE
fix: check if the cached audio is playable or not

### DIFF
--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -232,7 +232,7 @@ func playExistingMusic(musicPath string, shouldWait bool, ffStderr, ytStderr *os
 	_, err := exec.LookPath("ffprobe")
 	if err != nil {
 		notificationTitle := "ffprobe is missing"
-		notificationMessage := "ffprobe is missing, please install it helps us to check the status of cached audio"
+		notificationMessage := "ffprobe is missing, please install it to enable cached audio validation"
 		notification.Notify(notificationTitle, notificationMessage)
 		return nil, false, err
 	}

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -281,6 +281,10 @@ func playExistingMusic(musicPath string, shouldWait bool, ffStderr, ytStderr *os
 		slog.Error(err.Error())
 		notificationTitle := "Audio Processing Failed"
 		notificationMessage := err.Error()
+		err = f.Close()
+		if err != nil {
+			slog.Error(err.Error())
+		}
 		notification.Notify(notificationTitle, notificationMessage)
 		return nil, false, err
 	}
@@ -288,6 +292,12 @@ func playExistingMusic(musicPath string, shouldWait bool, ffStderr, ytStderr *os
 	ctx, ready, err := getOtoContext()
 	if err != nil {
 		slog.Error(err.Error())
+		_ = f.Close()
+		_ = pw.Close()
+		_ = pr.Close()
+		if ff.Process != nil {
+			_ = ff.Process.Kill()
+		}
 		return nil, false, err
 	}
 	if shouldWait {

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -282,8 +282,8 @@ func playExistingMusic(musicPath string, shouldWait bool, ffStderr, ytStderr *os
 		notificationTitle := "Audio Processing Failed"
 		notificationMessage := err.Error()
 		err = f.Close()
-		if err != nil {
-			slog.Error(err.Error())
+		if closeErr := f.Close(); closeErr != nil {
+			slog.Error(closeErr.Error())
 		}
 		notification.Notify(notificationTitle, notificationMessage)
 		return nil, false, err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate cached music is playable before use (auto-fallback to re-download when not).
  * Notify users when required media tooling is missing or when audio files fail to open or process.
  * Improve error handling and cleanup for audio playback startup and processing failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->