### PR TITLE
fix: trim notification message content

### DIFF
--- a/internal/notification/notify.go
+++ b/internal/notification/notify.go
@@ -45,9 +45,17 @@ func getAppIconPath() string {
 func Notify(title string, message string) {
 	beeep.AppName = "Clispot"
 	logo := getAppIconPath()
-
-	err := beeep.Notify(title, message, logo)
+	shortenMessage := trimWithEllipsis(message, 300)
+	err := beeep.Notify(title, shortenMessage, logo)
 	if err != nil {
 		slog.Error(err.Error())
 	}
+}
+
+func trimWithEllipsis(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Notification messages exceeding 300 characters are now automatically truncated with an ellipsis (...) to ensure proper display and prevent overly long notifications from being cut off.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->