### PR TITLE
fix(windows): can't write to a lock file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,8 +89,8 @@ func isProcessRunning(pid int) bool {
 
 func showAnotherProcessIsRunning(lockFilePath string) {
 	if runtime.GOOS == "windows" {
-		// windows doesn't allow us to read the content of the if the file is acquired by another process
-		fmt.Println("Another instance of clispot is not running")
+		// Windows doesn't allow us to read the content of the file if the file is acquired by another process
+		fmt.Fprintf(os.Stderr, "Another instance of clispot is already running.\n")
 		return
 	}
 	pidBytes, readErr := os.ReadFile(lockFilePath)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform lock-file handling: Windows now avoids erroneous lock-file reads and provides clearer messaging when another instance is detected; non-Windows behavior remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->