### PR TITLE
fix(windows): use taskkill for killing child process

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
-	"os"
+	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -329,12 +330,12 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 		}
 		if m.LyricsServerProcess != nil {
 			if runtime.GOOS == "windows" {
-				err := m.LyricsServerProcess.Kill()
+				err := exec.Command("taskkill", "/PID", strconv.Itoa(m.LyricsServerProcess.Pid), "/F", "/T").Run()
 				if err != nil {
 					slog.Error(err.Error())
 				}
 			} else {
-				err := m.LyricsServerProcess.Signal(os.Interrupt)
+				err := m.LyricsServerProcess.Kill()
 				if err != nil {
 					slog.Error(err.Error())
 				}

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -191,13 +193,25 @@ func SearchAndDownloadMusic(
 			}
 
 			if ff.Process != nil {
-				if err := ff.Process.Kill(); err != nil {
+				var err error
+				if runtime.GOOS == "windows" {
+					err = exec.Command("taskkill", "/PID", strconv.Itoa(ff.Process.Pid), "/F", "/T").Run()
+				} else {
+					err = ff.Process.Kill()
+				}
+				if err != nil {
 					slog.Error(err.Error())
 					firstErr = err
 				}
 			}
 			if yt.Process != nil {
-				if err := yt.Process.Kill(); err != nil && firstErr == nil {
+				var err error
+				if runtime.GOOS == "windows" {
+					err = exec.Command("taskkill", "/PID", strconv.Itoa(yt.Process.Pid), "/F", "/T").Run()
+				} else {
+					err = yt.Process.Kill()
+				}
+				if err != nil {
 					slog.Error(err.Error())
 					firstErr = err
 				}
@@ -301,8 +315,14 @@ func playExistingMusic(musicPath string, shouldWait bool, ffStderr, ytStderr *os
 			slog.Error(closeErr.Error())
 		}
 		if ff.Process != nil {
-			if killErr := ff.Process.Kill(); killErr != nil {
-				slog.Error(killErr.Error())
+			var err error
+			if runtime.GOOS == "windows" {
+				err = exec.Command("taskkill", "/PID", strconv.Itoa(ff.Process.Pid), "/F", "/T").Run()
+			} else {
+				err = ff.Process.Kill()
+			}
+			if err != nil {
+				slog.Error(err.Error())
 			}
 		}
 		return nil, false, err
@@ -345,9 +365,14 @@ func playExistingMusic(musicPath string, shouldWait bool, ffStderr, ytStderr *os
 			if err != nil {
 				slog.Error(err.Error())
 			}
-
 			if ff.Process != nil {
-				if err := ff.Process.Kill(); err != nil {
+				var err error
+				if runtime.GOOS == "windows" {
+					err = exec.Command("taskkill", "/PID", strconv.Itoa(ff.Process.Pid), "/F", "/T").Run()
+				} else {
+					err = ff.Process.Kill()
+				}
+				if err != nil {
 					slog.Error(err.Error())
 					firstErr = err
 				}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background service termination reliability across Windows and non-Windows platforms.
  * Enhanced error handling and consistency during cleanup of auxiliary services.
  * Better stability in resource management when shutting down system processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->