### PR TITLE
fix(windows): send CTRL + C to close child process

### DIFF
--- a/internal/command/cmd_darwin.go
+++ b/internal/command/cmd_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin
+
+package command
+
+import (
+	"os"
+	"os/exec"
+)
+
+func ExecCommand(command string, args ...string) (*exec.Cmd, error) {
+	cmd := exec.Command(command, args...)
+	return cmd, nil
+}
+
+func KillProcess(p *os.Process) error {
+	return p.Kill()
+}

--- a/internal/command/cmd_linux.go
+++ b/internal/command/cmd_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package command
+
+import (
+	"os"
+	"os/exec"
+)
+
+func ExecCommand(command string, args ...string) (*exec.Cmd, error) {
+	cmd := exec.Command(command, args...)
+	return cmd, nil
+}
+
+func KillProcess(p *os.Process) error {
+	return p.Kill()
+}

--- a/internal/command/cmd_windows.go
+++ b/internal/command/cmd_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package command
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+func ExecCommand(command string, args ...string) (*exec.Cmd, error) {
+	cmd := exec.Command(command, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	return cmd, nil
+}
+
+func KillProcess(p *os.Process) error {
+	return windows.GenerateConsoleCtrlEvent(syscall.CTRL_C_EVENT, uint32(p.Pid))
+}

--- a/internal/lyrics/lyrics.go
+++ b/internal/lyrics/lyrics.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"syscall"
 	"time"
 )
 
@@ -95,6 +96,9 @@ func IsLyricsServerRunning() (bool, error) {
 
 func StartLyricsServer() (*os.Process, error) {
 	cmd := exec.Command("clispot-lyrics")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
 	err := cmd.Start()
 	if err != nil {
 		slog.Error(err.Error())

--- a/internal/lyrics/lyrics.go
+++ b/internal/lyrics/lyrics.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"os/exec"
-	"syscall"
 	"time"
+
+	"github.com/kumneger0/clispot/internal/command"
 )
 
 const (
@@ -95,10 +95,8 @@ func IsLyricsServerRunning() (bool, error) {
 }
 
 func StartLyricsServer() (*os.Process, error) {
-	cmd := exec.Command("clispot-lyrics")
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
-	}
+	cmd, _ := command.ExecCommand("clispot-lyrics")
+
 	err := cmd.Start()
 	if err != nil {
 		slog.Error(err.Error())

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/godbus/dbus/v5"
+	"github.com/kumneger0/clispot/internal/command"
 	"github.com/kumneger0/clispot/internal/lyrics"
 	"github.com/kumneger0/clispot/internal/notification"
 	"github.com/kumneger0/clispot/internal/spotify"
@@ -326,7 +327,7 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 			}
 		}
 		if m.LyricsServerProcess != nil {
-			err := youtube.KillProcess(m.LyricsServerProcess)
+			err := command.KillProcess(m.LyricsServerProcess)
 			if err != nil {
 				slog.Error(err.Error())
 			}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
-	"os"
-	"runtime"
 	"strings"
 	"time"
 
@@ -328,16 +326,9 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 			}
 		}
 		if m.LyricsServerProcess != nil {
-			if runtime.GOOS == "windows" {
-				err := m.LyricsServerProcess.Kill()
-				if err != nil {
-					slog.Error(err.Error())
-				}
-			} else {
-				err := m.LyricsServerProcess.Signal(os.Interrupt)
-				if err != nil {
-					slog.Error(err.Error())
-				}
+			err := youtube.KillProcess(m.LyricsServerProcess)
+			if err != nil {
+				slog.Error(err.Error())
 			}
 		}
 		return m, tea.Quit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and unified command launch/termination across platforms for more consistent shutdown behavior.
  * Improved process/group handling and cross-platform support to enhance stability and resource cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->