### PR TITLE
fix(log): log command using hard coded path

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -3,18 +3,31 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 
+	"github.com/kumneger0/clispot/internal/config"
 	"github.com/spf13/cobra"
 )
 
 func clispotLog() *cobra.Command {
+	userConfig := config.GetUserConfig(runtime.GOOS)
 	return &cobra.Command{
+
 		Use:          "log",
 		Short:        "show log files use it for error reporting",
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
-			logs, err := os.ReadFile("/tmp/clispot.log")
+			if userConfig == nil {
+				fmt.Println("No user config found.")
+				return
+			}
+			if userConfig.DebugDir == nil {
+				fmt.Println("No debug directory configured.")
+				return
+			}
+			logs, err := os.ReadFile(filepath.Join(*userConfig.DebugDir, "clispot.log"))
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error reading log file: %v", err)
 				os.Exit(1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug log location is now configurable via user settings. Logs are retrieved from the user-configured debug directory instead of a fixed system path, providing greater flexibility in organizing debug logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->