### PR TITLE
fix(install): make filenames platform specific during install

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -244,16 +244,24 @@ func extractBinaries(targetDir, archivePath string) error {
 func extractZipBinaries(targetDir, zipPath string) error {
 	r, err := zip.OpenReader(zipPath)
 	if err != nil {
+		slog.Error(err.Error())
 		return err
 	}
 	defer r.Close()
 
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		slog.Error(err.Error())
 		return err
 	}
 
 	for _, f := range r.File {
-		if !strings.HasSuffix(f.Name, "ffmpeg") && !strings.HasSuffix(f.Name, "ffprobe") {
+		ffmpegFileName := "ffmpeg"
+		ffprobeFileName := "ffprobe"
+		if runtime.GOOS == "windows" {
+			ffmpegFileName = "ffmpeg.exe"
+			ffprobeFileName = "ffprobe.exe"
+		}
+		if !strings.HasSuffix(f.Name, ffmpegFileName) && !strings.HasSuffix(f.Name, ffprobeFileName) {
 			continue
 		}
 
@@ -261,11 +269,13 @@ func extractZipBinaries(targetDir, zipPath string) error {
 
 		rc, err := f.Open()
 		if err != nil {
+			slog.Error(err.Error())
 			return err
 		}
 
 		outFile, err := os.Create(outPath)
 		if err != nil {
+			slog.Error(err.Error())
 			rc.Close()
 			return err
 		}
@@ -274,6 +284,7 @@ func extractZipBinaries(targetDir, zipPath string) error {
 		outFile.Close()
 		rc.Close()
 		if err != nil {
+			slog.Error(err.Error())
 			return err
 		}
 

--- a/internal/install/yt-dlp.go
+++ b/internal/install/yt-dlp.go
@@ -37,7 +37,15 @@ var YtDlp = func(ctx context.Context) (*ResolvedInstall, error) {
 		return nil, nil
 	}
 
-	ytDlpDirectory := filepath.Join(config.GetCacheDir(runtime.GOOS), "yt-dlp")
+	var fileName string
+
+	if runtime.GOOS == "windows" {
+		fileName = "yt-dlp.exe"
+	} else {
+		fileName = "yt-dlp"
+	}
+
+	ytDlpDirectory := filepath.Join(config.GetCacheDir(runtime.GOOS), fileName)
 	checksumDir := filepath.Join(config.GetCacheDir(runtime.GOOS), "yt-dlp-checksum")
 	plat, err := detectPlatform()
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed binary extraction to properly handle platform-specific executable names (including .exe on Windows)
  * Enhanced error handling and logging during installation processes
  * Improved cross-platform reliability for binary caching and retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->