### PR TITLE
feat:  add `SkipOnNoMatch` config to automatically to play the next song if no match found

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -216,11 +216,19 @@ func runRoot(cmd *cobra.Command) error {
 		ytDlpArgs.Cookies = &cookiesFile
 	}
 
+	isHeadlessMode, err := cmd.Flags().GetBool("headless")
+
+	if err != nil {
+		slog.Error(err.Error())
+	}
+
 	config.SetConfig(&config.Config{
 		DebugDir:      &debugDir,
 		CacheDisabled: isCacheDisabled,
 		CacheDir:      &cacheDir,
 		YtDlpArgs:     &ytDlpArgs,
+		HeadlessMode:  isHeadlessMode,
+		SkipOnNoMatch: configFromFile.SkipOnNoMatch,
 	})
 
 	logger := logSetup.Init(debugDir)
@@ -277,12 +285,6 @@ func runRoot(cmd *cobra.Command) error {
 			fmt.Printf("we have failed to refresh ur token could you try deleting clispot dir by using rm -rf %v  ", clispotConfigDir)
 			os.Exit(1)
 		}
-	}
-
-	isHeadlessMode, err := cmd.Flags().GetBool("headless")
-
-	if err != nil {
-		slog.Error(err.Error())
 	}
 
 	ins, messageChan, err := mpris.GetDbusInstance()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	CacheDir      *string    `json:"cache-dir"`
 	YtDlpArgs     *YtDlpArgs `json:"yt-dlp-args"`
 	HeadlessMode  bool       `json:"headless-mode"`
+	SkipOnNoMatch bool       `json:"skip-on-no-match"`
 }
 
 var userConfigDir = os.UserConfigDir
@@ -81,6 +82,7 @@ func GetDefaultConfig(goos string) *Config {
 		CacheDir:      &defaultCacheDir,
 		YtDlpArgs:     &YtDlpArgs{},
 		HeadlessMode:  false,
+		SkipOnNoMatch: true,
 	}
 }
 

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -24,7 +24,7 @@ import (
 
 type Player struct {
 	OtoPlayer         *oto.Player
-	Close             func(isSkip bool) error
+	Close             func(shouldRemoveTheCacheFile bool) error
 	ByteCounterReader *byteCounterReader
 }
 
@@ -226,7 +226,7 @@ func SearchAndDownloadMusic(
 	return &Player{
 		OtoPlayer:         player,
 		ByteCounterReader: counter,
-		Close: func(isSkip bool) error {
+		Close: func(shouldRemoveTheCacheFile bool) error {
 			var firstErr error
 			if player != nil {
 				player.Close()
@@ -260,7 +260,7 @@ func SearchAndDownloadMusic(
 				_ = cacheFile.Close()
 			}
 
-			if isSkip {
+			if shouldRemoveTheCacheFile {
 				if err := os.Remove(musicPath); err != nil && !os.IsNotExist(err) && firstErr == nil {
 					slog.Error(err.Error())
 					firstErr = err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `SkipOnNoMatch` configuration option to automatically skip tracks when YouTube matches cannot be found (defaults to enabled).

* **Chores**
  * Streamlined headless mode flag retrieval to reduce redundant operations.
  * Enhanced cache file management logic for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->