### PR TITLE
fix: use go channels to update played seconds instead of tea.Tick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ wheels/
 browser.json
 gen/
 backend/main
+main.spec

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -334,6 +334,15 @@ func runRoot(cmd *cobra.Command) error {
 		}
 	}()
 
+	go func() {
+		if types.PlayedSecondsUpdateChan == nil {
+			return
+		}
+		for data := range types.PlayedSecondsUpdateChan {
+			Program.Send(data)
+		}
+	}()
+
 	_, err = Program.Run()
 	if err != nil {
 		slog.Error(err.Error())

--- a/internal/types/msgs.go
+++ b/internal/types/msgs.go
@@ -30,8 +30,10 @@ type UpdatePlaylistMsg struct {
 	ShouldAppend      bool
 }
 
-type UpdatePlayedSeconds struct {
-	TrackID string
+var PlayedSecondsUpdateChan = make(chan PlayedSecondsUpdateMsg, 10)
+
+type PlayedSecondsUpdateMsg struct {
+	CurrentSeconds float64
 }
 
 type MessageType string
@@ -93,6 +95,10 @@ func (b *ByteCounterReader) Read(p []byte) (int, error) {
 	}
 	if err != nil && err != io.EOF {
 		slog.Error(err.Error())
+	}
+
+	PlayedSecondsUpdateChan <- PlayedSecondsUpdateMsg{
+		CurrentSeconds: b.CurrentSeconds(),
 	}
 	return n, err
 }

--- a/internal/types/msgs.go
+++ b/internal/types/msgs.go
@@ -92,14 +92,17 @@ func (b *ByteCounterReader) Read(p []byte) (int, error) {
 	n, err := b.R.Read(p)
 	if n > 0 {
 		atomic.AddInt64(&b.total, int64(n))
+		select {
+		case PlayedSecondsUpdateChan <- PlayedSecondsUpdateMsg{
+			CurrentSeconds: b.CurrentSeconds(),
+		}:
+		default:
+		}
 	}
 	if err != nil && err != io.EOF {
 		slog.Error(err.Error())
 	}
 
-	PlayedSecondsUpdateChan <- PlayedSecondsUpdateMsg{
-		CurrentSeconds: b.CurrentSeconds(),
-	}
 	return n, err
 }
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -119,14 +118,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			_ = msg.Player.Close()
 			return m, nil
 		}
-		cmd := func() tea.Msg {
-			if msg.Player != nil {
-				return types.UpdatePlayedSeconds{
-					TrackID: msg.VideoID,
-				}
-			}
-			return nil
-		}
 		likedCmd := func() tea.Msg {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -144,7 +135,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Err:   err,
 			}
 		}
-		cmds = append(cmds, cmd, likedCmd)
+		cmds = append(cmds, likedCmd)
 		m.PlayerProcess = msg.Player
 	case types.CheckUserSavedTrackResponseMsg:
 		if msg.Err != nil {
@@ -204,44 +195,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.TrackID == m.SelectedTrack.Track.Track.ID {
 			m.SelectedTrack.isLiked = msg.Like
 		}
-	case types.UpdatePlayedSeconds:
-		if m.PlayerProcess == nil {
-			return m, nil
-		}
-		if err := m.PlayerProcess.OtoPlayer.Err(); err != nil {
-			slog.Error(err.Error())
-			alertCmd := m.Alert.NewAlertCmd(bubbleup.ErrorKey, err.Error())
-			cmds = append(cmds, alertCmd)
-		}
-		if !m.PlayerProcess.OtoPlayer.IsPlaying() {
-			return m, nil
-		}
-
-		if m.SelectedTrack == nil || m.SelectedTrack.Track == nil {
-			return m, nil
-		}
-
-		if msg.TrackID != m.SelectedTrack.Track.Track.ID {
-			return m, nil
-		}
-
+	case types.PlayedSecondsUpdateMsg:
 		m.PlayedSeconds = m.PlayerProcess.ByteCounterReader.CurrentSeconds()
 		totalDurationInSeconds := m.SelectedTrack.Track.Track.DurationMS / 1000
-		if (float64(totalDurationInSeconds) - (m.PlayedSeconds)) < 4 {
+		if (float64(totalDurationInSeconds) - (m.PlayedSeconds)) < 1 {
 			m.PlayedSeconds = 0
 			model, cmd := m.handleMusicChange(true, false)
 			m = model
 			cmds = append(cmds, cmd)
 		}
-
-		trackID := m.SelectedTrack.Track.Track.ID
-
-		cmd := tea.Tick(time.Second*1, func(t time.Time) tea.Msg {
-			return types.UpdatePlayedSeconds{
-				TrackID: trackID,
-			}
-		})
-		cmds = append(cmds, cmd)
 
 	case tea.WindowSizeMsg:
 		m.Width = msg.Width - 4

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -76,6 +76,7 @@ func SearchAndDownloadMusic(
 		logPathName := appConfig.DebugDir
 		ffStderr, err := os.Create(filepath.Join(*logPathName, "ffstderr.log"))
 		if err != nil {
+			slog.Error(err.Error())
 			return types.SearchAndDownloadMusicMsg{
 				Player:  nil,
 				VideoID: videoID,
@@ -83,17 +84,29 @@ func SearchAndDownloadMusic(
 			}
 		}
 
-		ff, _ := command.ExecCommand(ctx,
+		ff, err := command.ExecCommand(ctx,
 			coreDepsPath.FFmpeg,
 			"-reconnect", "1",
 			"-reconnect_streamed", "1",
 			"-reconnect_delay_max", "5",
+			"-reconnect_at_eof", "1",
+			"-reconnect_on_network_error", "1",
+			"-reconnect_on_http_error", "1",
 			"-i", streamURL,
 			"-f", "s16le",
 			"-ac", "2",
 			"-ar", "44100",
 			"pipe:1",
 		)
+
+		if err != nil {
+			slog.Error(err.Error())
+			return types.SearchAndDownloadMusicMsg{
+				Player:  nil,
+				VideoID: videoID,
+				Err:     err,
+			}
+		}
 
 		pr, pw := ringbuffer.New(1024 * 1024 * 5).Pipe()
 

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -100,6 +100,7 @@ func SearchAndDownloadMusic(
 		)
 
 		if err != nil {
+			_ = ffStderr.Close()
 			slog.Error(err.Error())
 			return types.SearchAndDownloadMusicMsg{
 				Player:  nil,

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -89,7 +89,6 @@ func SearchAndDownloadMusic(
 			"-reconnect", "1",
 			"-reconnect_streamed", "1",
 			"-reconnect_delay_max", "5",
-			"-reconnect_at_eof", "1",
 			"-reconnect_on_network_error", "1",
 			"-reconnect_on_http_error", "1",
 			"-i", streamURL,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playback progress now updates the interface in near real time.
  * Improved automatic track transitions when playback is nearly complete.
  * Media downloads are more resilient to network interruptions.

* **Bug Fixes**
  * Clearer error handling when media playback setup or logging fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->