### PR TITLE
feat: add support for related songs and lyrics

### DIFF
--- a/grpc_server/main.py
+++ b/grpc_server/main.py
@@ -1,5 +1,5 @@
 from concurrent import futures
-from types import FrameType
+from types import FrameType, UnionType
 import grpc
 import os
 import sys
@@ -29,19 +29,27 @@ from grpc_server.src.client.types import (  # pyright: ignore[reportImplicitRela
     YTSearchFilter
 )
 
-def _to_proto_thumbnail(thumb: YTThumbnail | dict[str, Any]) -> music_pb2.Thumbnail:
-    return music_pb2.Thumbnail(
-        url=str(thumb.get("url") or ""),
-        width=int(thumb.get("width") or 0),
-        height=int(thumb.get("height") or 0),
-    )
+def _to_proto_thumbnail(thumb: YTThumbnail | dict[str, Any] | str) -> music_pb2.Thumbnail:
+    if isinstance(thumb, str):
+        return music_pb2.Thumbnail(url=thumb, width=0, height=0)
+    if isinstance(thumb, dict):
+        return music_pb2.Thumbnail(
+            url=str(thumb.get("url") or ""),
+            width=int(thumb.get("width") or 0),
+            height=int(thumb.get("height") or 0),
+        )
+    return music_pb2.Thumbnail(url="", width=0, height=0)
 
 
-def _to_proto_artist(artist: YTArtist | dict[str, Any]) -> music_pb2.Artist:
-    return music_pb2.Artist(
-        id=str(artist.get("id") or ""),
-        name=str(artist.get("name") or ""),
-    )
+def _to_proto_artist(artist: YTArtist | dict[str, Any] | str) -> music_pb2.Artist:
+    if isinstance(artist, str):
+        return music_pb2.Artist(id="", name=artist)
+    if isinstance(artist, dict):
+        return music_pb2.Artist(
+            id=str(artist.get("id") or ""),
+            name=str(artist.get("name") or ""),
+        )
+    return music_pb2.Artist(id="", name=str(artist or ""))
 
 
 def _to_proto_song(song: YTSong) -> music_pb2.Song:
@@ -386,18 +394,28 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
         for result in raw_results:
             result_type = result.get("resultType")
             if result_type == "song":
+                dur_val = result.get("duration_seconds")
+                dur_int = 0
+                if isinstance(dur_val, int):
+                    dur_int = dur_val
+                elif isinstance(dur_val, str):
+                    try:
+                        dur_int = int(dur_val)
+                    except ValueError:
+                        pass
+
                 song_item = music_pb2.SearchResultSong(
-                    video_id=result.get("videoId") or "",
-                    title=result.get("title") or "",
+                    video_id=str(result.get("videoId") or ""),
+                    title=str(result.get("title") or ""),
                     album="",
                     album_id="",
-                    duration_seconds=result.get("duration_seconds") or 0,
+                    duration_seconds=dur_int,
                     is_explicit=bool(result.get("isExplicit")),
                 )
                 album_info = result.get("album")
                 if isinstance(album_info, dict):
-                    song_item.album = album_info.get("name") or ""
-                    song_item.album_id = album_info.get("id") or ""
+                    song_item.album = str(album_info.get("name") or "")
+                    song_item.album_id = str(album_info.get("id") or "")
                 elif isinstance(album_info, str):
                     song_item.album = album_info
 
@@ -409,10 +427,10 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 
             elif result_type == "album":
                 album_item = music_pb2.SearchResultAlbum(
-                    browse_id=result.get("browseId") or "",
-                    title=result.get("title") or "",
-                    year=result.get("year") or "",
-                    type=result.get("type") or "",
+                    browse_id=str(result.get("browseId") or ""),
+                    title=str(result.get("title") or ""),
+                    year=str(result.get("year") or ""),
+                    type=str(result.get("type") or ""),
                     is_explicit=bool(result.get("isExplicit")),
                 )
                 for artist in (result.get("artists") or []):
@@ -423,9 +441,9 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 
             elif result_type == "artist":
                 artist_item = music_pb2.SearchResultArtist(
-                    browse_id=result.get("browseId") or "",
-                    name=result.get("artist") or "",
-                    subscribers=result.get("subscribers") or "",
+                    browse_id=str(result.get("browseId") or ""),
+                    name=str(result.get("artist") or ""),
+                    subscribers=str(result.get("subscribers") or ""),
                 )
                 for thumbnail in (result.get("thumbnails") or []):
                     artist_item.thumbnails.append(_to_proto_thumbnail(thumbnail))
@@ -433,10 +451,10 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 
             elif result_type == "playlist":
                 playlist_item = music_pb2.SearchResultPlaylist(
-                    browse_id=result.get("browseId") or "",
-                    title=result.get("title") or "",
-                    author=result.get("author") or "",
-                    item_count=result.get("itemCount") or "",
+                    browse_id=str(result.get("browseId") or ""),
+                    title=str(result.get("title") or ""),
+                    author=str(result.get("author") or ""),
+                    item_count=str(result.get("itemCount") or ""),
                 )
                 for thumbnail in (result.get("thumbnails") or []):
                     playlist_item.thumbnails.append(_to_proto_thumbnail(thumbnail))
@@ -487,18 +505,28 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 response.episodes.append(episode_item)
 
             elif result_type == "video":
+                dur_val = result.get("duration_seconds")
+                dur_int = 0
+                if isinstance(dur_val, int):
+                    dur_int = dur_val
+                elif isinstance(dur_val, str):
+                    try:
+                        dur_int = int(dur_val)
+                    except ValueError:
+                        pass
+
                 song_item = music_pb2.SearchResultSong(
-                    video_id=result.get("videoId") or "",
-                    title=result.get("title") or "",
+                    video_id=str(result.get("videoId") or ""),
+                    title=str(result.get("title") or ""),
                     album="",
                     album_id="",
-                    duration_seconds=result.get("duration_seconds") or 0,
+                    duration_seconds=dur_int,
                     is_explicit=bool(result.get("isExplicit")),
                 )
                 album_info = result.get("album")
                 if isinstance(album_info, dict):
-                    song_item.album = album_info.get("name") or ""
-                    song_item.album_id = album_info.get("id") or ""
+                    song_item.album = str(album_info.get("name") or "")
+                    song_item.album_id = str(album_info.get("id") or "")
                 elif isinstance(album_info, str):
                     song_item.album = album_info
 
@@ -657,12 +685,15 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
         context: grpc.ServicerContext,
     ) -> music_pb2.GetSongRelatedResponse:
         try:
-            browse_id = request.browse_id
-            if browse_id and not browse_id.startswith("MPTRt_"):
-                watch_data = self.client.get_watch_playlist(browse_id)
+            browse_id = getattr(request, "browse_id", None) or getattr(request, "videoId", None)
+            if not browse_id or not browse_id.startswith("MPTRt_"):
+                watch_data = self.client.get_watch_playlist(request.videoId)
                 related_id = watch_data.get("related")
                 if isinstance(related_id, str) and related_id:
                     browse_id = related_id
+
+            if browse_id is None:
+                return music_pb2.GetSongRelatedResponse()
 
             sections_data = self.client.get_song_related(browse_id)
             response = music_pb2.GetSongRelatedResponse()
@@ -691,13 +722,15 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
         context: grpc.ServicerContext,
     ) -> music_pb2.GetLyricsResponse:
         try:
-            browse_id = request.browse_id
-            if browse_id and not browse_id.startswith("MPLYt_"):
-                watch_data = self.client.get_watch_playlist(browse_id)
-                lyrics_id = watch_data.get("lyrics")
-                if isinstance(lyrics_id, str) and lyrics_id:
-                    browse_id = lyrics_id
+            browse_id = None
+            watch_data = self.client.get_watch_playlist(request.videoId)
+            lyrics_id = watch_data.get("lyrics")
+            if isinstance(lyrics_id, str) and lyrics_id:
+                browse_id = lyrics_id
 
+            if browse_id is None:
+                return music_pb2.GetLyricsResponse()
+                
             raw_lyrics = self.client.get_lyrics(
                 browse_id=browse_id,
                 timestamps=request.timestamps,

--- a/grpc_server/main.py
+++ b/grpc_server/main.py
@@ -3,7 +3,7 @@ from types import FrameType
 import grpc
 import os
 import sys
-from typing import Callable, override
+from typing import Callable, override, Any, cast
 import signal
 from dotenv import load_dotenv
 _= load_dotenv()
@@ -29,18 +29,18 @@ from grpc_server.src.client.types import (  # pyright: ignore[reportImplicitRela
     YTSearchFilter
 )
 
-def _to_proto_thumbnail(thumb: YTThumbnail) -> music_pb2.Thumbnail:
+def _to_proto_thumbnail(thumb: YTThumbnail | dict[str, Any]) -> music_pb2.Thumbnail:
     return music_pb2.Thumbnail(
-        url=thumb.get("url") or "",
-        width=thumb.get("width") or 0,
-        height=thumb.get("height") or 0,
+        url=str(thumb.get("url") or ""),
+        width=int(thumb.get("width") or 0),
+        height=int(thumb.get("height") or 0),
     )
 
 
-def _to_proto_artist(artist: YTArtist) -> music_pb2.Artist:
+def _to_proto_artist(artist: YTArtist | dict[str, Any]) -> music_pb2.Artist:
     return music_pb2.Artist(
-        id=artist.get("id") or "",
-        name=artist.get("name") or "",
+        id=str(artist.get("id") or ""),
+        name=str(artist.get("name") or ""),
     )
 
 
@@ -50,8 +50,12 @@ def _to_proto_song(song: YTSong) -> music_pb2.Song:
     album_id = ""
     album_data = song.get("album")
     if isinstance(album_data, dict):
-        album_name = album_data.get("name") or ""
-        album_id = album_data.get("id") or ""
+        name_val = album_data.get("name")
+        id_val = album_data.get("id")
+        if isinstance(name_val, str):
+            album_name = name_val
+        if isinstance(id_val, str):
+            album_id = id_val
     elif isinstance(album_data, str):
         album_name = album_data
 
@@ -103,7 +107,11 @@ def _to_proto_playlist(playlist: YTLibraryPlaylist) -> music_pb2.Playlist:
     author_name = ""
     author_val = playlist.get("author")
     if isinstance(author_val, list) and len(author_val) > 0:
-        author_name = author_val[0].get("name") or ""
+        first_author: object = author_val[0]
+        if isinstance(first_author, dict):
+            name_val = str(first_author.get("name") or "")
+            if name_val:
+                author_name = name_val
     elif isinstance(author_val, str):
         author_name = author_val
 
@@ -143,23 +151,30 @@ def _to_proto_followed_artist(artist: YTLibraryArtist) -> music_pb2.FollowedArti
 
 def _to_proto_podcast(podcast: YTLibraryPlaylist) -> music_pb2.Podcast:
     author_name = ""
-    channel = podcast.get("channel")
+    channel: object = podcast.get("channel")
     if isinstance(channel, dict):
-        author_name = channel.get("name") or ""
+        val = str(channel.get("name") or "")
+        if val:
+            author_name = val
 
     if not author_name:
         author_val = podcast.get("author")
         if isinstance(author_val, list) and len(author_val) > 0:
-            author_name = author_val[0].get("name") or ""
+            first_author: object = author_val[0]
+            if isinstance(first_author, dict):
+                val = str(first_author.get("name") or "")
+                if val:
+                    author_name = val
         elif isinstance(author_val, str):
             author_name = author_val
 
-    podcast_id = (
+    podcast_id_val = (
         podcast.get("podcastId")
         or podcast.get("playlistId")
         or podcast.get("browseId")
         or ""
     )
+    podcast_id = str(podcast_id_val)
 
     podcast_msg = music_pb2.Podcast(
         podcast_id=podcast_id,
@@ -169,6 +184,60 @@ def _to_proto_podcast(podcast: YTLibraryPlaylist) -> music_pb2.Podcast:
     for thumbnail in (podcast.get("thumbnails") or []):
         podcast_msg.thumbnails.append(_to_proto_thumbnail(thumbnail))
     return podcast_msg
+
+
+def to_proto_song_related_content(content: dict[str, Any]) -> music_pb2.SongRelatedContent:
+    album_name = ""
+    album_id = ""
+    album_data = content.get("album")
+    if isinstance(album_data, dict):
+        name_val = album_data.get("name")
+        if isinstance(name_val, str):
+            album_name = name_val
+        id_val = album_data.get("id")
+        if isinstance(id_val, str):
+            album_id = id_val
+    elif isinstance(album_data, str):
+        album_name = album_data
+
+    content_type = ""
+    if content.get("videoId"):
+        content_type = "song"
+    elif content.get("playlistId"):
+        content_type = "playlist"
+    elif content.get("subscribers"):
+        content_type = "artist"
+    elif content.get("browseId"):
+        if str(content.get("browseId")).startswith("MPRE"):
+            content_type = "album"
+        else:
+            content_type = "artist"
+
+    content_msg = music_pb2.SongRelatedContent(
+        title=str(content.get("title") or ""),
+        video_id=str(content.get("videoId") or ""),
+        playlist_id=str(content.get("playlistId") or ""),
+        browse_id=str(content.get("browseId") or ""),
+        is_explicit=bool(content.get("isExplicit") or content.get("is_explicit")),
+        album=album_name,
+        album_id=album_id,
+        description=str(content.get("description") or ""),
+        subscribers=str(content.get("subscribers") or ""),
+        year=str(content.get("year")) if content.get("year") is not None else "",
+        content_type=content_type,
+    )
+
+    raw_artists = content.get("artists")
+    if isinstance(raw_artists, list):
+        for artist in raw_artists:
+            content_msg.artists.append(_to_proto_artist(cast(dict[str, Any], artist)))
+
+    raw_thumbnails = content.get("thumbnails")
+    if isinstance(raw_thumbnails, list):
+        for thumbnail in raw_thumbnails:
+            content_msg.thumbnails.append(_to_proto_thumbnail(cast(dict[str, Any], thumbnail)))
+
+    return content_msg
 
 
 class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
@@ -377,13 +446,15 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 author_val = result.get("author")
                 author_str = ""
                 if isinstance(author_val, dict):
-                    author_str = author_val.get("name") or ""
+                    name_val = author_val.get("name")
+                    if isinstance(name_val, str):
+                        author_str = name_val
                 elif isinstance(author_val, str):
                     author_str = author_val
 
                 podcast_item = music_pb2.SearchResultPodcast(
-                    browse_id=result.get("browseId") or "",
-                    title=result.get("title") or "",
+                    browse_id=str(result.get("browseId") or ""),
+                    title=str(result.get("title") or ""),
                     author=author_str,
                 )
                 for thumbnail in (result.get("thumbnails") or []):
@@ -395,17 +466,21 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 podcast_name = ""
                 podcast_id = ""
                 if isinstance(podcast_info, dict):
-                    podcast_name = podcast_info.get("name") or ""
-                    podcast_id = podcast_info.get("id") or ""
+                    name_val = podcast_info.get("name")
+                    id_val = podcast_info.get("id")
+                    if isinstance(name_val, str):
+                        podcast_name = name_val
+                    if isinstance(id_val, str):
+                        podcast_id = id_val
                 elif isinstance(podcast_info, str):
                     podcast_name = podcast_info
 
                 episode_item = music_pb2.SearchResultEpisode(
-                    video_id=result.get("videoId") or "",
-                    title=result.get("title") or "",
+                    video_id=str(result.get("videoId") or ""),
+                    title=str(result.get("title") or ""),
                     podcast_name=podcast_name,
                     podcast_id=podcast_id,
-                    date=result.get("date") or "",
+                    date=str(result.get("date") or ""),
                 )
                 for thumbnail in (result.get("thumbnails") or []):
                     episode_item.thumbnails.append(_to_proto_thumbnail(thumbnail))
@@ -534,40 +609,139 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 title=section.get("title") or ""
             )
             
-            for content in section.get("contents", []):
-                playlist_id = content.get("playlistId") or ""
-                video_id = content.get("videoId") or ""
-                browse_id = content.get("browseId") or ""
-                content_type = "playlist"
-                if video_id:
-                    content_type = "song"
-                elif browse_id and browse_id.startswith("MPRE"):
-                    content_type = "album"
-                elif browse_id and (browse_id.startswith("UC") or browse_id.startswith("FKYt")):
-                    content_type = "artist"
-                elif playlist_id:
+            contents: object = section.get("contents")
+            if isinstance(contents, list):
+                for content in contents:
+                    if not isinstance(content, dict):
+                        continue
+                    playlist_id = str(content.get("playlistId") or "")
+                    video_id = str(content.get("videoId") or "")
+                    browse_id = str(content.get("browseId") or "")
                     content_type = "playlist"
-                elif browse_id:
-                    playlist_id = browse_id
-                    content_type = "playlist"
+                    if video_id:
+                        content_type = "song"
+                    elif browse_id and browse_id.startswith("MPRE"):
+                        content_type = "album"
+                    elif browse_id and (browse_id.startswith("UC") or browse_id.startswith("FKYt")):
+                        content_type = "artist"
+                    elif playlist_id:
+                        content_type = "playlist"
+                    elif browse_id:
+                        playlist_id = browse_id
+                        content_type = "playlist"
 
-                content_msg = music_pb2.HomePageContent(
-                    title=content.get("title") or "",
-                    playlist_id=playlist_id,
-                    video_id=video_id,
-                    browse_id=browse_id,
-                    content_type=content_type,
-                    description=content.get("description") or ""
-                )
-                
-                for thumbnail in content.get("thumbnails", []):
-                    content_msg.thumbnails.append(_to_proto_thumbnail(thumbnail))
-                
-                section_msg.contents.append(content_msg)
-            
+                    content_msg = music_pb2.HomePageContent(
+                        title=str(content.get("title") or ""),
+                        playlist_id=playlist_id,
+                        video_id=video_id,
+                        browse_id=browse_id,
+                        content_type=content_type,
+                        description=str(content.get("description") or "")
+                    )
+
+                    thumbnails = content.get("thumbnails")
+                    if isinstance(thumbnails, list):
+                        for thumbnail in thumbnails:
+                            content_msg.thumbnails.append(_to_proto_thumbnail(cast(dict[str, Any], thumbnail)))
+
+                    section_msg.contents.append(content_msg)
+
             response.sections.append(section_msg)
-        
+
         return response
+
+    @override
+    def GetSongRelated(
+        self,
+        request: music_pb2.GetSongRelatedRequest,
+        context: grpc.ServicerContext,
+    ) -> music_pb2.GetSongRelatedResponse:
+        try:
+            browse_id = request.browse_id
+            if browse_id and not browse_id.startswith("MPTRt_"):
+                watch_data = self.client.get_watch_playlist(browse_id)
+                related_id = watch_data.get("related")
+                if isinstance(related_id, str) and related_id:
+                    browse_id = related_id
+
+            sections_data = self.client.get_song_related(browse_id)
+            response = music_pb2.GetSongRelatedResponse()
+            for section in sections_data:
+                sec_msg = music_pb2.SongRelatedSection(
+                    title=str(section.get("title") or "")
+                )
+                contents_data = section.get("contents")
+                if isinstance(contents_data, str):
+                    sec_msg.text_content = contents_data
+                elif isinstance(contents_data, list):
+                    for item in contents_data:
+                        sec_msg.contents.append(to_proto_song_related_content(cast(dict[str, Any], item)))
+                response.sections.append(sec_msg)
+            return response
+        except Exception as e:
+            print(f"Error in GetSongRelated: {e}")
+            context.set_code(grpc.StatusCode.INTERNAL)
+            context.set_details(str(e))
+            return music_pb2.GetSongRelatedResponse()
+
+    @override
+    def GetLyrics(
+        self,
+        request: music_pb2.GetLyricsRequest,
+        context: grpc.ServicerContext,
+    ) -> music_pb2.GetLyricsResponse:
+        try:
+            browse_id = request.browse_id
+            if browse_id and not browse_id.startswith("MPLYt_"):
+                watch_data = self.client.get_watch_playlist(browse_id)
+                lyrics_id = watch_data.get("lyrics")
+                if isinstance(lyrics_id, str) and lyrics_id:
+                    browse_id = lyrics_id
+
+            raw_lyrics = self.client.get_lyrics(
+                browse_id=browse_id,
+                timestamps=request.timestamps,
+            )
+            if not raw_lyrics:
+                return music_pb2.GetLyricsResponse()
+
+            def _get_val(obj: object, key: str) -> object:
+                if isinstance(obj, dict):
+                    return obj.get(key)
+                return getattr(obj, key, None)
+
+            source = str(_get_val(raw_lyrics, "source") or "")
+            has_timestamps = bool(_get_val(raw_lyrics, "hasTimestamps") or False)
+            lyrics_data = _get_val(raw_lyrics, "lyrics")
+
+            response = music_pb2.GetLyricsResponse(
+                source=source,
+                has_timestamps=has_timestamps,
+            )
+
+            if has_timestamps and isinstance(lyrics_data, list):
+                for line in lyrics_data:
+                    line_text = str(_get_val(line, "text") or "")
+                    start_time = int(cast(int, _get_val(line, "start_time") or 0))
+                    end_time = int(cast(int, _get_val(line, "end_time") or 0))
+                    line_id = int(cast(int, _get_val(line, "id") or 0))
+                    response.lines.append(
+                        music_pb2.LyricLine(
+                            text=line_text,
+                            start_time=start_time,
+                            end_time=end_time,
+                            id=line_id,
+                        )
+                    )
+            elif isinstance(lyrics_data, str):
+                response.lyrics = lyrics_data
+
+            return response
+        except Exception as e:
+            print(f"Error in GetLyrics: {e}")
+            context.set_code(grpc.StatusCode.INTERNAL)
+            context.set_details(str(e))
+            return music_pb2.GetLyricsResponse()
 
 
 

--- a/grpc_server/src/auth.py
+++ b/grpc_server/src/auth.py
@@ -347,8 +347,10 @@ def process_raw_headers_via_ytmusicapi(raw_headers: str, filepath: Path | None =
         return False, str(e), target_path
 
 
+from typing import Mapping
+
 class WebLoginHandler(BaseHTTPRequestHandler):
-    def log_message(self, format, *args):
+    def log_message(self, format: str, *args: object) -> None:
         pass
 
     def do_GET(self):
@@ -389,7 +391,7 @@ class WebLoginHandler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
 
-    def _send_json(self, status_code: int, data: dict):
+    def _send_json(self, status_code: int, data: Mapping[str, object]):
         self.send_response(status_code)
         self.send_header("Content-Type", "application/json; charset=utf-8")
         self.end_headers()

--- a/grpc_server/src/client/client.py
+++ b/grpc_server/src/client/client.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import cast, Any
 from ytmusicapi import  YTMusic, LikeStatus
 from yt_dlp import YoutubeDL
 
@@ -160,3 +160,17 @@ class MusicClient:
             video_id,
             LikeStatus.INDIFFERENT
         )
+
+    def get_song_related(self, browse_id: str) -> list[dict[str, Any]]:
+        raw_related: object = self.client.get_song_related(browseId=browse_id)
+        return cast(list[dict[str, Any]], cast(object, raw_related))
+
+    def get_lyrics(self, browse_id: str, timestamps: bool = False) -> object:
+        raw_lyrics: object = self.client.get_lyrics(browseId=browse_id, timestamps=timestamps)
+        return raw_lyrics
+
+    def get_watch_playlist(self, video_id: str) -> dict[str, Any]:
+        raw_watch: object = self.client.get_watch_playlist(videoId=video_id)
+        if isinstance(raw_watch, dict):
+            return cast(dict[str, Any], raw_watch)
+        return {}

--- a/internal/types/msgs.go
+++ b/internal/types/msgs.go
@@ -128,3 +128,13 @@ type GetLibraryMsg struct {
 	Result *musicpb.GetLibraryResponse
 	Err    error
 }
+
+type RelatedSongsMsg struct {
+	Related *musicpb.GetSongRelatedResponse
+	Err     error
+}
+
+type LyricsMsg struct {
+	LyricsResponse *musicpb.GetLyricsResponse
+	Err            error
+}

--- a/internal/ui/renderers.go
+++ b/internal/ui/renderers.go
@@ -47,8 +47,15 @@ func (d CustomDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 				isSelected = m.Index() == index
 			}
 		case QueueList:
-			if m.Title == "Related" || m.Title == "Queue" {
-				isSelected = m.Index() == index
+			showRelated := (d.Model.RightColumnMode == RightColumnRelated || d.Model.RightColumnMode == "") && len(d.Model.RelatedList.Items()) > 0
+			if showRelated {
+				if m.Title == "Related" {
+					isSelected = m.Index() == index
+				}
+			} else {
+				if m.Title == "Queue" {
+					isSelected = m.Index() == index
+				}
 			}
 		}
 	}
@@ -303,6 +310,7 @@ func renderPlayerControls(m *Model) string {
 		key.Render("♥")+label.Render(" like")+dimmerStyle.Render("(l)"),
 		key.Render("✕")+label.Render(" quit")+dimmerStyle.Render("(q)"),
 		key.Render("📝")+label.Render(" lyrics")+dimmerStyle.Render("(ctrl+l)"),
+		key.Render("🔄")+label.Render(" queue/related")+dimmerStyle.Render("(ctrl+q)"),
 	)
 	return strings.Join(parts, sep)
 }

--- a/internal/ui/renderers.go
+++ b/internal/ui/renderers.go
@@ -36,9 +36,25 @@ func (d CustomDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 	var icon string
 	var subtitle string
 
+	if d.Model != nil {
+		switch d.Model.FocusedOn {
+		case SideView:
+			if m.Title == "Youtube Music tui" || m.Title == "Library" {
+				isSelected = m.Index() == index
+			}
+		case MainView:
+			if m.Title != "Related" && m.Title != "Queue" && m.Title != "Youtube Music tui" {
+				isSelected = m.Index() == index
+			}
+		case QueueList:
+			if m.Title == "Related" || m.Title == "Queue" {
+				isSelected = m.Index() == index
+			}
+		}
+	}
+
 	switch item := item.(type) {
 	case types.SearchResultItem:
-		isSelected = d.Model != nil && d.Model.FocusedOn == MainView && m.Index() == index
 		title = item.Title()
 		switch item.Kind() {
 		case types.SearchResultTrack:
@@ -102,24 +118,9 @@ func (d CustomDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 			}
 			subtitle = strings.Join(names, ", ")
 		}
-		if d.Model != nil {
-			switch d.Model.FocusedOn {
-			case QueueList:
-				if item.IsItFromQueue {
-					isSelected = m.Index() == index
-				}
-			case MainView:
-				if !item.IsItFromQueue && item.IsItFromSearch == false {
-					isSelected = m.Index() == index
-				}
-			}
-		}
 	case types.SidebarItem:
 		icon = item.Icon
 		title = item.Name
-		if d.Model != nil && d.Model.FocusedOn == SideView {
-			isSelected = m.Index() == index
-		}
 	case types.HomePageContentItem:
 		if item.VideoID != "" || item.ContentType == "song" || item.ContentType == "video" {
 			icon = "♫"
@@ -130,21 +131,12 @@ func (d CustomDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 		}
 		title = item.ItemTitle
 		subtitle = item.Description
-		if d.Model != nil && d.Model.FocusedOn == MainView && d.Model.MainViewMode == HomePageMode {
-			isSelected = m.Index() == index
-		}
 	case types.HomePageSectionItem:
 		icon = "▸"
 		title = item.SectionTitle
-		if d.Model != nil && d.Model.FocusedOn == MainView && d.Model.MainViewMode == HomePageMode {
-			isSelected = m.Index() == index
-		}
 	case types.UserSavedTracksListItem:
 		title = item.FilterValue()
-		if d.Model != nil {
-			icon = "♥"
-			isSelected = d.Model.FocusedOn == SideView && m.Index() == index
-		}
+		icon = "♥"
 	}
 
 	availableWidth := m.Width()

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -53,6 +53,13 @@ const (
 	HomePageContentView
 )
 
+type RightColumnMode string
+
+const (
+	RightColumnQueue   RightColumnMode = "RIGHT_COLUMN_QUEUE"
+	RightColumnRelated RightColumnMode = "RIGHT_COLUMN_RELATED"
+)
+
 type SpotifySearchResult struct {
 	Tracks, Artists, Albums, Playlists list.Model
 }
@@ -104,6 +111,7 @@ type Model struct {
 	HomePageList     list.Model
 	HomePageViewMode HomePageViewMode
 	RelatedList      list.Model
+	RightColumnMode  RightColumnMode
 }
 
 type Instance struct {
@@ -248,7 +256,8 @@ func (m Model) View() string {
 		Foreground(playerFg).
 		Render(playingCombined)
 	var rightColumnView string
-	if len(m.RelatedList.Items()) > 0 {
+	showRelated := (m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "") && len(m.RelatedList.Items()) > 0
+	if showRelated {
 		rightColumnView = m.RelatedList.View()
 	} else if m.MusicQueueList != nil {
 		rightColumnView = m.MusicQueueList.View()

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -103,6 +103,7 @@ type Model struct {
 	HomePageData     *musicpb.GetHomePageResponse
 	HomePageList     list.Model
 	HomePageViewMode HomePageViewMode
+	RelatedList      list.Model
 }
 
 type Instance struct {
@@ -180,6 +181,10 @@ func (m Model) View() string {
 	removeListDefaults(&m.SearchResult)
 	removeListDefaults(&m.HomePageList)
 	removeListDefaults(&m.MusicQueueList.Model)
+	if len(m.RelatedList.Items()) > 0 {
+		m.RelatedList.Title = "Related"
+		removeListDefaults(&m.RelatedList)
+	}
 	m.SearchResult.SetShowTitle(false)
 	m.SelectedPlayListItems.SetShowTitle(false)
 	m.HomePageList.SetShowTitle(false)
@@ -188,6 +193,9 @@ func (m Model) View() string {
 	m.SelectedPlayListItems.SetSize(dimensions.mainWidth, dimensions.contentHeight-4)
 	m.SearchResult.SetSize(dimensions.mainWidth, dimensions.contentHeight-4)
 	m.HomePageList.SetSize(dimensions.mainWidth, dimensions.contentHeight-4)
+	if len(m.RelatedList.Items()) > 0 {
+		m.RelatedList.SetSize(dimensions.sidebarWidth, dimensions.contentHeight)
+	}
 	if m.MusicQueueList != nil {
 		m.MusicQueueList.Model.SetSize(dimensions.sidebarWidth, dimensions.contentHeight)
 	}
@@ -233,7 +241,13 @@ func (m Model) View() string {
 	playing := getPlayerStyles(&m, dimensions).
 		Foreground(playerFg).
 		Render(playingCombined)
-	queueList := getStyle(&m, dimensions.contentHeight, dimensions.sidebarWidth, QueueList, false).Render(m.MusicQueueList.View())
+	var rightColumnView string
+	if len(m.RelatedList.Items()) > 0 {
+		rightColumnView = m.RelatedList.View()
+	} else if m.MusicQueueList != nil {
+		rightColumnView = m.MusicQueueList.View()
+	}
+	queueList := getStyle(&m, dimensions.contentHeight, dimensions.sidebarWidth, QueueList, false).Render(rightColumnView)
 	combinedView := lipgloss.JoinVertical(lipgloss.Top,
 		lipgloss.JoinHorizontal(lipgloss.Top, sideBarView, mainView, queueList),
 		playing,

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -112,6 +112,7 @@ type Model struct {
 	HomePageViewMode HomePageViewMode
 	RelatedList      list.Model
 	RightColumnMode  RightColumnMode
+	CurrentLyrics    *musicpb.GetLyricsResponse
 }
 
 type Instance struct {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -214,8 +214,14 @@ func (m Model) View() string {
 			lipgloss.JoinVertical(lipgloss.Top, searchBar, resultHeader, lipgloss.NewStyle().Padding(1, 0, 0, 0).Render(m.SearchResult.View())),
 		)
 	} else if m.MainViewMode == LyricsMode {
+		trackName := ""
+		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil {
+			trackName = " • " + m.SelectedTrack.Track.Track.Name
+		}
+		lyricsHeader := titleStyle.Render("  📝 Lyrics" + trackName)
+		lyricsPadded := lipgloss.NewStyle().Padding(1, 2).Render(m.LyricsView.View())
 		mainView = getStyle(&m, dimensions.contentHeight, dimensions.mainWidth, MainView, false).Render(
-			lipgloss.JoinVertical(lipgloss.Top, searchBar, breadcrumb, m.LyricsView.View()),
+			lipgloss.JoinVertical(lipgloss.Top, searchBar, breadcrumb, lyricsHeader, lyricsPadded),
 		)
 	} else if m.MainViewMode == HomePageMode {
 		mainView = getStyle(&m, dimensions.contentHeight, dimensions.mainWidth, MainView, false).Render(

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -347,6 +347,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.RelatedList = list.New(items, CustomDelegate{Model: &m}, width, m.Height)
 		removeListDefaults(&m.RelatedList)
 		m.RelatedList.Title = "Related"
+		m.RightColumnMode = RightColumnRelated
 		return m, nil
 	case types.LyricsMsg:
 		if msg.Err != nil || msg.LyricsResponse == nil {
@@ -551,8 +552,23 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 			return m, nil
 		}
 		return m.handleMusicChange(true)
+	case "ctrl+q", "t":
+		if m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "" {
+			m.RightColumnMode = RightColumnQueue
+		} else {
+			m.RightColumnMode = RightColumnRelated
+		}
+		return m, nil
 	case "q", "ctrl+c":
 		if m.FocusedOn == SearchBar {
+			return m, nil
+		}
+		if msg.String() == "q" && m.FocusedOn == QueueList && len(m.RelatedList.Items()) > 0 {
+			if m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "" {
+				m.RightColumnMode = RightColumnQueue
+			} else {
+				m.RightColumnMode = RightColumnRelated
+			}
 			return m, nil
 		}
 		if m.BackendProcess != nil && m.BackendProcess.Process != nil {
@@ -903,7 +919,8 @@ func getListItemForMusicToChoose(m *Model, focusedOn FocusedOn) *list.Model {
 		return &m.SelectedPlayListItems
 	}
 	if focusedOn == QueueList {
-		if len(m.RelatedList.Items()) > 0 {
+		showRelated := (m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "") && len(m.RelatedList.Items()) > 0
+		if showRelated {
 			return &m.RelatedList
 		}
 		if m.MusicQueueList != nil {
@@ -993,9 +1010,6 @@ func (m Model) playTrackFromList(track types.PlaylistTrackObject, rawItems []lis
 			items = append(items, playlistItem)
 		}
 	}
-	if m.FocusedOn != QueueList {
-		m.RelatedList.SetItems([]list.Item{})
-	}
 	m.MusicQueueList.Model.SetItems(items)
 	m.MusicQueueList.Model.Select(m.MusicQueueList.GlobalIndex())
 	return m.PlaySelectedMusic(track)
@@ -1076,7 +1090,19 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 
 	switch selectedItem := listItemToChooseMusicFrom.SelectedItem().(type) {
 	case types.PlaylistTrackObject:
-		return m.playTrackFromList(selectedItem, m.SelectedPlayListItems.Items())
+		relatedSongsCmd := func() tea.Msg {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			relatedSongs, err := m.YtMusicClient.GetSongRelated(ctx, &musicpb.GetSongRelatedRequest{
+				BrowseId: selectedItem.Track.ID,
+			})
+			return types.RelatedSongsMsg{
+				Related: relatedSongs,
+				Err:     err,
+			}
+		}
+		m, cmd := m.playTrackFromList(selectedItem, m.SelectedPlayListItems.Items())
+		return m, tea.Batch(cmd, relatedSongsCmd)
 
 	case types.Playlist:
 		return m.navigateToDetailView(m.getPlaylistItems(selectedItem.ID))
@@ -1112,9 +1138,10 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 					Name: selectedItem.ItemTitle,
 				},
 			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+
 			relatedSongsCmd := func() tea.Msg {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 				relatedSongs, err := m.YtMusicClient.GetSongRelated(ctx, &musicpb.GetSongRelatedRequest{
 					BrowseId: playlistTrack.Track.ID,
 				})
@@ -1493,7 +1520,8 @@ func updateFocusedComponent(m *Model, msg tea.Msg, cmdsFromParent *[]tea.Cmd) (M
 		cmds = append(cmds, cmd)
 	case QueueList:
 		var cmd tea.Cmd
-		if len(m.RelatedList.Items()) > 0 {
+		showRelated := (m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "") && len(m.RelatedList.Items()) > 0
+		if showRelated {
 			m.RelatedList, cmd = m.RelatedList.Update(msg)
 		} else if m.MusicQueueList != nil {
 			m.MusicQueueList.Model, cmd = m.MusicQueueList.Model.Update(msg)

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -263,7 +263,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		totalDurationInSeconds := m.SelectedTrack.Track.Track.DurationMS / 1000
 		if totalDurationInSeconds > 0 && (float64(totalDurationInSeconds)-m.PlayedSeconds) < 1 {
 			m.PlayedSeconds = 0
-			model, cmd := m.handleMusicChange(true, false)
+			model, cmd := m.handleMusicChange(true)
 			m = model
 			cmds = append(cmds, cmd)
 		}
@@ -320,6 +320,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			alertCmd := m.Alert.NewAlertCmd(bubbleup.ErrorKey, msg.Err.Error())
 			cmds = append(cmds, alertCmd)
 		}
+	case types.RelatedSongsMsg:
+		if msg.Err != nil || msg.Related == nil || len(msg.Related.Sections) == 0 {
+			return m, nil
+		}
+		var items []list.Item
+		for _, section := range msg.Related.Sections {
+			if section.Title != "" {
+				items = append(items, types.HomePageSectionItem{SectionTitle: section.Title})
+			}
+			for _, content := range section.Contents {
+				items = append(items, MapSongRelatedContentToListItem(content))
+			}
+			if section.TextContent != "" {
+				items = append(items, types.HomePageContentItem{
+					ItemTitle:   section.Title,
+					Description: section.TextContent,
+				})
+			}
+		}
+		width := m.LibraryWidth
+		if width <= 0 {
+			width = 30
+		}
+		m.RelatedList = list.New(items, CustomDelegate{Model: &m}, width, m.Height)
+		removeListDefaults(&m.RelatedList)
+		m.RelatedList.Title = "Related"
+		return m, nil
 	case tea.KeyMsg:
 		model, cmd := m.handleKeyPress(msg)
 		m = model
@@ -348,12 +375,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) handleDbusMessage(msg types.MessageType, cmds []tea.Cmd) (Model, tea.Cmd) {
 	switch msg {
 	case types.NextTrack:
-		model, cmd := m.handleMusicChange(true, true)
+		model, cmd := m.handleMusicChange(true)
 		m = model
 		cmds = append(cmds, cmd)
 		return m, tea.Batch(cmds...)
 	case types.PreviousTrack:
-		model, cmd := m.handleMusicChange(false, true)
+		model, cmd := m.handleMusicChange(false)
 		m = model
 		cmds = append(cmds, cmd)
 		return m, tea.Batch(cmds...)
@@ -482,12 +509,12 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 		if m.FocusedOn != Player {
 			return m, nil
 		}
-		return m.handleMusicChange(false, true)
+		return m.handleMusicChange(false)
 	case "n":
 		if m.FocusedOn != Player {
 			return m, nil
 		}
-		return m.handleMusicChange(true, true)
+		return m.handleMusicChange(true)
 	case "q", "ctrl+c":
 		if m.FocusedOn == SearchBar {
 			return m, nil
@@ -582,7 +609,7 @@ func (m Model) getMusicLyrics(track *SelectedTrack) (Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) handleMusicChange(isForward, shouldRemoveTheCacheFile bool) (Model, tea.Cmd) {
+func (m Model) handleMusicChange(isForward bool) (Model, tea.Cmd) {
 	if m.MusicQueueList == nil {
 		return m, nil
 	}
@@ -767,6 +794,61 @@ func (m Model) HandleMusicPausePlay() (Model, tea.Cmd) {
 	return m, nil
 }
 
+func MapSongRelatedContentToListItem(content *musicpb.SongRelatedContent) list.Item {
+	if content.VideoId != "" || content.ContentType == "song" || content.ContentType == "video" {
+		var artists []types.Artist
+		for _, a := range content.Artists {
+			artists = append(artists, types.Artist{
+				ID:   a.Id,
+				Name: a.Name,
+			})
+		}
+		return types.PlaylistTrackObject{
+			Track: types.Track{
+				ID:      content.VideoId,
+				Name:    content.Title,
+				Artists: artists,
+			},
+		}
+	}
+	if content.ContentType == "album" || strings.HasPrefix(content.BrowseId, "MPRE") {
+		var artists []types.Artist
+		for _, a := range content.Artists {
+			artists = append(artists, types.Artist{
+				ID:   a.Id,
+				Name: a.Name,
+			})
+		}
+		return types.Album{
+			ID:      content.BrowseId,
+			Name:    content.Title,
+			Artists: artists,
+			Year:    content.Year,
+		}
+	}
+	if content.ContentType == "artist" || content.Subscribers != "" {
+		return types.Artist{
+			ID:   content.BrowseId,
+			Name: content.Title,
+		}
+	}
+	if content.PlaylistId != "" || content.ContentType == "playlist" {
+		return types.Playlist{
+			ID:          content.PlaylistId,
+			Name:        content.Title,
+			Description: content.Description,
+		}
+	}
+	return types.HomePageContentItem{
+		ItemTitle:   content.Title,
+		PlaylistID:  content.PlaylistId,
+		VideoID:     content.VideoId,
+		BrowseID:    content.BrowseId,
+		ContentType: content.ContentType,
+		Description: content.Description,
+	}
+}
+
 func getListItemForMusicToChoose(m *Model, focusedOn FocusedOn) *list.Model {
 	if focusedOn == MainView && m.MainViewMode == HomePageMode {
 		if m.HomePageViewMode == HomePageSectionView {
@@ -779,471 +861,360 @@ func getListItemForMusicToChoose(m *Model, focusedOn FocusedOn) *list.Model {
 	if focusedOn == MainView && m.MainViewMode == NormalMode {
 		return &m.SelectedPlayListItems
 	}
-	if focusedOn == QueueList && m.MusicQueueList != nil {
-		return &m.MusicQueueList.Model
+	if focusedOn == QueueList {
+		if len(m.RelatedList.Items()) > 0 {
+			return &m.RelatedList
+		}
+		if m.MusicQueueList != nil {
+			return &m.MusicQueueList.Model
+		}
 	}
 	return nil
 }
 
 func (m Model) handleEnterKey() (Model, tea.Cmd) {
-	if m.FocusedOn == SideView {
-		if item, ok := m.SideBarList.SelectedItem().(types.SidebarItem); ok {
-			newBreadcrumbItems := []types.Breadcrumb{{Name: item.Name, Icon: item.Icon}}
-			m.BreadcrumbItems = newBreadcrumbItems
-			if strings.ToLower(strings.Trim(item.Name, " ")) == "home" {
-				homePageFeed := func() tea.Msg {
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
-					homePage, err := m.YtMusicClient.GetHomePage(ctx, &musicpb.GetHomePageRequest{})
-					if err != nil {
-						slog.Error(err.Error())
-						return types.HomePageResponseMsg{
-							Response: homePage,
-							Err:      err,
-						}
-					}
-					return types.HomePageResponseMsg{
-						Response: homePage,
-						Err:      nil,
-					}
-				}
-				return m, tea.Batch(SendLoadingCmd(), homePageFeed)
+	switch m.FocusedOn {
+	case SideView:
+		return m.handleSidebarEnter()
+	case MainView, QueueList:
+		return m.handleMainViewOrQueueEnter()
+	case SearchBar:
+		return m.handleSearchBarEnter()
+	default:
+		return m, nil
+	}
+}
+
+func (m Model) handleSidebarEnter() (Model, tea.Cmd) {
+	item, ok := m.SideBarList.SelectedItem().(types.SidebarItem)
+	if !ok {
+		return m, nil
+	}
+	m.BreadcrumbItems = []types.Breadcrumb{{Name: item.Name, Icon: item.Icon}}
+	itemName := strings.ToLower(strings.TrimSpace(item.Name))
+
+	if itemName == "home" {
+		homePageFeed := func() tea.Msg {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			homePage, err := m.YtMusicClient.GetHomePage(ctx, &musicpb.GetHomePageRequest{})
+			return types.HomePageResponseMsg{
+				Response: homePage,
+				Err:      err,
 			}
-			if strings.ToLower(strings.Trim(item.Name, " ")) == "library" {
-				libraryCmd := func() tea.Msg {
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
-					library, err := m.YtMusicClient.GetLibrary(ctx, &musicpb.GetLibraryRequest{Limit: 100})
-					return types.GetLibraryMsg{
-						Result: library,
-						Err:    err,
-					}
-				}
-				return m, tea.Batch(SendLoadingCmd(), libraryCmd)
+		}
+		return m, tea.Batch(SendLoadingCmd(), homePageFeed)
+	}
+
+	if itemName == "library" {
+		libraryCmd := func() tea.Msg {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			library, err := m.YtMusicClient.GetLibrary(ctx, &musicpb.GetLibraryRequest{Limit: 100})
+			return types.GetLibraryMsg{
+				Result: library,
+				Err:    err,
 			}
+		}
+		return m, tea.Batch(SendLoadingCmd(), libraryCmd)
+	}
+
+	return m, nil
+}
+
+func (m Model) navigateToDetailView(cmd tea.Cmd) (Model, tea.Cmd) {
+	m.MainViewMode = NormalMode
+	m.FocusedOn = MainView
+	updateDelegate(&m)
+	return m, tea.Batch(cmd, SendLoadingCmd())
+}
+
+func (m Model) playTrackFromList(track types.PlaylistTrackObject, rawItems []list.Item) (Model, tea.Cmd) {
+	if m.MusicQueueList == nil {
+		return m, nil
+	}
+	var items []list.Item
+	for _, rawItem := range rawItems {
+		if homeContent, ok := rawItem.(types.HomePageContentItem); ok && homeContent.VideoID != "" {
+			playlistTrack := types.PlaylistTrackObject{
+				Track: types.Track{
+					ID:   homeContent.VideoID,
+					Name: homeContent.ItemTitle,
+				},
+				IsItFromQueue: true,
+			}
+			items = append(items, playlistTrack)
+		} else if playlistTrack, ok := rawItem.(types.PlaylistTrackObject); ok {
+			playlistItem := types.PlaylistTrackObject{
+				Track:         playlistTrack.Track,
+				IsItFromQueue: true,
+			}
+			items = append(items, playlistItem)
 		}
 	}
-	if m.FocusedOn == MainView || m.FocusedOn == QueueList {
-		if m.MainViewMode == HomePageMode && m.HomePageViewMode == HomePageSectionView {
-			listItemToChooseMusicFrom := getListItemForMusicToChoose(&m, m.FocusedOn)
-			if listItemToChooseMusicFrom == nil {
-				return m, nil
-			}
-			item, ok := listItemToChooseMusicFrom.SelectedItem().(types.HomePageSectionItem)
-			if !ok {
-				return m, nil
-			}
-			cmd := func() tea.Msg {
-				return types.UpdateHomePageContentMsg{
-					Item: item,
-				}
-			}
-			newBreadcrumbItems := []types.Breadcrumb{{Name: item.SectionTitle, Icon: ""}}
-			m.BreadcrumbItems = append(m.BreadcrumbItems, newBreadcrumbItems...)
-			return m, cmd
-		}
+	if m.FocusedOn != QueueList {
+		m.RelatedList.SetItems([]list.Item{})
+	}
+	m.MusicQueueList.Model.SetItems(items)
+	m.MusicQueueList.Model.Select(m.MusicQueueList.GlobalIndex())
+	return m.PlaySelectedMusic(track)
+}
 
-		if m.MainViewMode == HomePageMode && m.HomePageViewMode == HomePageContentView {
-			item, ok := m.HomePageList.SelectedItem().(types.HomePageContentItem)
-			if !ok {
-				return m, nil
-			}
-			if item.VideoID != "" || item.ContentType == "song" || item.ContentType == "video" {
-				trackID := item.VideoID
-				if trackID == "" {
-					trackID = item.PlaylistID
-				}
-				playlistTrack := types.PlaylistTrackObject{
-					Track: types.Track{
-						ID:   trackID,
-						Name: item.ItemTitle,
-					},
-				}
-				var items []list.Item
-				for _, item := range m.HomePageList.Items() {
-					homePageContent, ok := item.(types.HomePageContentItem)
-					if !ok || homePageContent.VideoID == "" {
-						continue
-					}
-					playlistTrack := types.PlaylistTrackObject{
-						Track: types.Track{
-							ID:   homePageContent.VideoID,
-							Name: homePageContent.ItemTitle,
-						},
-						IsItFromQueue: true,
-					}
-					items = append(items, playlistTrack)
-				}
-				if m.MusicQueueList == nil {
-					return m, nil
-				}
-				m.MusicQueueList.Model.SetItems(items)
-				m.MusicQueueList.Model.Select(m.MusicQueueList.GlobalIndex())
-				return m.PlaySelectedMusic(playlistTrack)
-			} else if item.ContentType == "album" || strings.HasPrefix(item.BrowseID, "MPRE") {
-				browseID := item.BrowseID
-				if browseID == "" {
-					browseID = item.PlaylistID
-				}
-				loadingCmd := SendLoadingCmd()
-				cmd := m.getAlbumTracks(browseID)
-				m.MainViewMode = NormalMode
-				m.FocusedOn = MainView
-				updateDelegate(&m)
-				return m, tea.Batch(cmd, loadingCmd)
-			}
-			playlistID := item.PlaylistID
-			if playlistID == "" {
-				playlistID = item.BrowseID
-			}
-			playlistDetailMsg := func() tea.Msg {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				playlistItems, err := m.YtMusicClient.GetPlaylistItems(ctx, &musicpb.GetPlaylistItemsRequest{
-					PlaylistId: playlistID,
-				})
-				return types.PlaylistDetailMsg{
-					Playlist: playlistItems,
-					Err:      err,
-				}
-			}
-			newBreadcrumbItems := []types.Breadcrumb{{Name: item.ItemTitle, Icon: ""}}
-			m.BreadcrumbItems = append(m.BreadcrumbItems, newBreadcrumbItems...)
-			return m, tea.Batch(SendLoadingCmd(), playlistDetailMsg)
-		}
-
+func (m Model) handleHomePageEnter() (Model, tea.Cmd) {
+	if m.HomePageViewMode == HomePageSectionView {
 		listItemToChooseMusicFrom := getListItemForMusicToChoose(&m, m.FocusedOn)
 		if listItemToChooseMusicFrom == nil {
 			return m, nil
 		}
-
-		switch selectedItem := listItemToChooseMusicFrom.SelectedItem().(type) {
-		case types.PlaylistTrackObject:
-			var items []list.Item
-			for _, item := range m.SelectedPlayListItems.Items() {
-				playlistTrack, ok := item.(types.PlaylistTrackObject)
-				if !ok {
-					continue
-				}
-				playlistItem := types.PlaylistTrackObject{
-					Track:         playlistTrack.Track,
-					IsItFromQueue: true,
-				}
-				items = append(items, playlistItem)
-			}
-			if m.MusicQueueList == nil {
-				return m, nil
-			}
-			m.MusicQueueList.Model.SetItems(items)
-			m.MusicQueueList.Model.Select(m.MusicQueueList.GlobalIndex())
-			return m.PlaySelectedMusic(selectedItem)
-
-		case types.Playlist:
-			loadingCmd := SendLoadingCmd()
-			cmd := m.getPlaylistItems(selectedItem.ID)
-			m.MainViewMode = NormalMode
-			m.FocusedOn = MainView
-			updateDelegate(&m)
-			return m, tea.Batch(cmd, loadingCmd)
-
-		case types.Album:
-			loadingCmd := SendLoadingCmd()
-			cmd := m.getAlbumTracks(selectedItem.ID)
-			m.MainViewMode = NormalMode
-			m.FocusedOn = MainView
-			updateDelegate(&m)
-			return m, tea.Batch(cmd, loadingCmd)
-
-		case types.Artist:
-			loadingCmd := SendLoadingCmd()
-			cmd := m.getArtistTracks(selectedItem.ID)
-			m.MainViewMode = NormalMode
-			m.FocusedOn = MainView
-			updateDelegate(&m)
-			return m, tea.Batch(cmd, loadingCmd)
-
-		case types.Podcast:
-			loadingCmd := SendLoadingCmd()
-			cmd := m.getPlaylistItems(selectedItem.ID)
-			m.MainViewMode = NormalMode
-			m.FocusedOn = MainView
-			updateDelegate(&m)
-			return m, tea.Batch(cmd, loadingCmd)
-
-		case types.Episode:
-			return m.PlaySelectedMusic(types.PlaylistTrackObject{
-				Track: types.Track{
-					ID:   selectedItem.ID,
-					Name: selectedItem.TitleName,
-					Artists: []types.Artist{
-						{Name: selectedItem.PodcastName},
-					},
-				},
-			})
-		}
-	}
-
-	if m.FocusedOn == SearchBar {
-		query := m.Search.Value()
-		if query == m.SearchQuery && len(m.SearchResult.Items()) > 0 {
-			m.MainViewMode = SearchResultMode
+		item, ok := listItemToChooseMusicFrom.SelectedItem().(types.HomePageSectionItem)
+		if !ok {
 			return m, nil
 		}
+		cmd := func() tea.Msg {
+			return types.UpdateHomePageContentMsg{Item: item}
+		}
+		m.BreadcrumbItems = append(m.BreadcrumbItems, types.Breadcrumb{Name: item.SectionTitle, Icon: ""})
+		return m, cmd
+	}
 
-		loadingCmd := SendLoadingCmd()
-		searchingCmd := func() tea.Msg {
+	if m.HomePageViewMode == HomePageContentView {
+		item, ok := m.HomePageList.SelectedItem().(types.HomePageContentItem)
+		if !ok {
+			return m, nil
+		}
+		if item.VideoID != "" || item.ContentType == "song" || item.ContentType == "video" {
+			trackID := item.VideoID
+			if trackID == "" {
+				trackID = item.PlaylistID
+			}
+			playlistTrack := types.PlaylistTrackObject{
+				Track: types.Track{
+					ID:   trackID,
+					Name: item.ItemTitle,
+				},
+			}
+			return m.playTrackFromList(playlistTrack, m.HomePageList.Items())
+		} else if item.ContentType == "album" || strings.HasPrefix(item.BrowseID, "MPRE") {
+			browseID := item.BrowseID
+			if browseID == "" {
+				browseID = item.PlaylistID
+			}
+			return m.navigateToDetailView(m.getAlbumTracks(browseID))
+		}
+		playlistID := item.PlaylistID
+		if playlistID == "" {
+			playlistID = item.BrowseID
+		}
+		playlistDetailMsg := func() tea.Msg {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-
-			searchResults, err := m.YtMusicClient.GetSearchResults(ctx, &musicpb.GetSearchResultsRequest{
-				Query: query,
+			playlistItems, err := m.YtMusicClient.GetPlaylistItems(ctx, &musicpb.GetPlaylistItemsRequest{
+				PlaylistId: playlistID,
 			})
-
-			if err != nil {
-				slog.Error(err.Error())
-				return types.SpotifySearchResultMsg{
-					Result: nil,
-					Err:    err,
-				}
-			}
-
-			var items []list.Item
-			for _, s := range searchResults.Songs {
-				track := types.MapSearchResultSongToTrack(s)
-				items = append(items, track)
-			}
-			for _, a := range searchResults.Artists {
-				artist := types.Artist{
-					ID:     a.BrowseId,
-					Name:   a.Name,
-					Images: types.MapThumbnailsToImages(a.Thumbnails),
-				}
-				items = append(items, artist)
-			}
-			for _, p := range searchResults.Playlists {
-				playlist := types.Playlist{
-					ID:          p.BrowseId,
-					Name:        p.Title,
-					Description: p.ItemCount,
-					Images:      types.MapThumbnailsToImages(p.Thumbnails),
-					Author:      p.Author,
-				}
-				items = append(items, playlist)
-			}
-			for _, al := range searchResults.Albums {
-				album := types.Album{
-					ID:      al.BrowseId,
-					Name:    al.Title,
-					Artists: types.MapArtistsToArtists(al.Artists),
-					Images:  types.MapThumbnailsToImages(al.Thumbnails),
-					Year:    al.Year,
-					Type:    al.Type,
-				}
-				items = append(items, album)
-			}
-			for _, pod := range searchResults.Podcasts {
-				podcast := types.Podcast{
-					ID:     pod.BrowseId,
-					Name:   pod.Title,
-					Author: pod.Author,
-					Images: types.MapThumbnailsToImages(pod.Thumbnails),
-				}
-				items = append(items, podcast)
-			}
-			for _, ep := range searchResults.Episodes {
-				episode := types.Episode{
-					ID:          ep.VideoId,
-					TitleName:   ep.Title,
-					PodcastName: ep.PodcastName,
-					PodcastID:   ep.PodcastId,
-					Date:        ep.Date,
-					Images:      types.MapThumbnailsToImages(ep.Thumbnails),
-				}
-				items = append(items, episode)
-			}
-
-			searchResult := &types.SearchResponse{
-				Items: items,
-			}
-
-			return types.SpotifySearchResultMsg{
-				Result: searchResult,
-				Err:    nil,
+			return types.PlaylistDetailMsg{
+				Playlist: playlistItems,
+				Err:      err,
 			}
 		}
-		m.SearchQuery = query
-		return m, tea.Batch(loadingCmd, searchingCmd)
+		m.BreadcrumbItems = append(m.BreadcrumbItems, types.Breadcrumb{Name: item.ItemTitle, Icon: ""})
+		return m, tea.Batch(SendLoadingCmd(), playlistDetailMsg)
 	}
 
-	if m.FocusedOn == SideView {
-		m.PaginationInfo = nil
-		loadingCmd := SendLoadingCmd()
-		switch selectedItem := m.SideBarList.SelectedItem().(type) {
-		case types.SidebarItem:
-			m.MainViewMode = HomePageMode
-			m.FocusedOn = MainView
-			updateDelegate(&m)
-			return m, nil
-		case types.Playlist:
-			cmd := m.getPlaylistItems(selectedItem.ID)
-			return m, tea.Batch(loadingCmd, cmd)
-		case types.Artist:
-			cmd := m.getArtistTracks(selectedItem.ID)
-			return m, tea.Batch(loadingCmd, cmd)
-		case types.UserSavedTracksListItem:
-			cmd := m.getUserSavedTracks()
-			return m, tea.Batch(loadingCmd, cmd)
-		}
-	}
-	if m.FocusedOn == MainView && m.MainViewMode == HomePageMode {
-		switch m.HomePageViewMode {
-		case HomePageSectionView:
-			selectedItem, ok := m.HomePageList.SelectedItem().(types.HomePageSectionItem)
-			if !ok {
-				slog.Error("failed to cast the selected item to types.HomePageSectionItem")
-				return m, nil
-			}
-			if m.HomePageData != nil && selectedItem.Index < len(m.HomePageData.Sections) {
-				section := m.HomePageData.Sections[selectedItem.Index]
-				var items []list.Item
-				for _, content := range section.Contents {
-					items = append(items, types.HomePageContentItem{
-						ItemTitle:   content.Title,
-						PlaylistID:  content.PlaylistId,
-						VideoID:     content.VideoId,
-						BrowseID:    content.BrowseId,
-						ContentType: content.ContentType,
-						Description: content.Description,
-					})
-				}
-				m.HomePageList = list.New(items, CustomDelegate{Model: &m}, 10, 20)
-				removeListDefaults(&m.HomePageList)
-				m.HomePageList.Title = section.Title
-				m.HomePageViewMode = HomePageContentView
-				return m, nil
-			}
-		case HomePageContentView:
-			selectedItem, ok := m.HomePageList.SelectedItem().(types.HomePageContentItem)
-			if !ok {
-				slog.Error("failed to cast the selected item to types.HomePageContentItem")
-				return m, nil
-			}
-			if selectedItem.VideoID != "" || selectedItem.ContentType == "song" || selectedItem.ContentType == "video" {
-				trackID := selectedItem.VideoID
-				if trackID == "" {
-					trackID = selectedItem.PlaylistID
-				}
-				playlistTrack := types.PlaylistTrackObject{
-					Track: types.Track{
-						ID:   trackID,
-						Name: selectedItem.ItemTitle,
-					},
-				}
-				return m.PlaySelectedMusic(playlistTrack)
-			} else if selectedItem.ContentType == "album" || strings.HasPrefix(selectedItem.BrowseID, "MPRE") {
-				browseID := selectedItem.BrowseID
-				if browseID == "" {
-					browseID = selectedItem.PlaylistID
-				}
-				loadingCmd := SendLoadingCmd()
-				cmd := m.getAlbumTracks(browseID)
-				m.MainViewMode = NormalMode
-				m.FocusedOn = MainView
-				updateDelegate(&m)
-				return m, tea.Batch(cmd, loadingCmd)
-			} else if selectedItem.PlaylistID != "" || selectedItem.BrowseID != "" {
-				playlistID := selectedItem.PlaylistID
-				if playlistID == "" {
-					playlistID = selectedItem.BrowseID
-				}
-				loadingCmd := SendLoadingCmd()
-				cmd := m.getPlaylistItems(playlistID)
-				m.MainViewMode = NormalMode
-				m.FocusedOn = MainView
-				updateDelegate(&m)
-				return m, tea.Batch(cmd, loadingCmd)
-			}
-		}
-	}
-	if m.FocusedOn == MainView && m.MainViewMode == SearchResultMode {
-		if selectedItem, ok := m.SearchResult.SelectedItem().(types.SearchResultItem); ok {
-			switch selectedItem.Kind() {
-			case types.SearchResultTrack:
-				track, ok := selectedItem.(types.Track)
-				if !ok {
-					slog.Error("failed to cast the selected item to types.Track")
-					return m, nil
-				}
-				return m.PlaySelectedMusic(types.PlaylistTrackObject{
-					Track: track,
-				})
-			case types.SearchResultPlaylist:
-				playlist, ok := selectedItem.(types.Playlist)
-				if !ok {
-					slog.Error("failed to cast the selected item to types.Playlist")
-					return m, nil
-				}
-				loadingCmd := SendLoadingCmd()
-				cmd := m.getPlaylistItems(playlist.ID)
-				m.MainViewMode = NormalMode
-				m.FocusedOn = MainView
-				updateDelegate(&m)
-				return m, tea.Batch(cmd, loadingCmd)
-			case types.SearchResultArtist:
-				artist, ok := selectedItem.(types.Artist)
-				if !ok {
-					slog.Error("failed to cast the selected item to types.Artist")
-					return m, nil
-				}
-				loadingCmd := SendLoadingCmd()
-				cmd := m.getArtistTracks(artist.ID)
-				m.MainViewMode = NormalMode
-				m.FocusedOn = MainView
-				updateDelegate(&m)
-				return m, tea.Batch(cmd, loadingCmd)
-			case types.SearchResultAlbum:
-				album, ok := selectedItem.(types.Album)
-				if !ok {
-					slog.Error("failed to cast the selected item to types.Album")
-					return m, nil
-				}
-				loadingCmd := SendLoadingCmd()
-				cmd := m.getAlbumTracks(album.ID)
-				m.MainViewMode = NormalMode
-				m.FocusedOn = MainView
-				updateDelegate(&m)
-				return m, tea.Batch(cmd, loadingCmd)
-			case types.SearchResultPodcast:
-				podcast, ok := selectedItem.(types.Podcast)
-				if !ok {
-					slog.Error("failed to cast the selected item to types.Podcast")
-					return m, nil
-				}
-				loadingCmd := SendLoadingCmd()
-				cmd := m.getPlaylistItems(podcast.ID)
-				m.MainViewMode = NormalMode
-				m.FocusedOn = MainView
-				updateDelegate(&m)
-				return m, tea.Batch(cmd, loadingCmd)
-			case types.SearchResultEpisode:
-				ep, ok := selectedItem.(types.Episode)
-				if !ok {
-					slog.Error("failed to cast the selected item to types.Episode")
-					return m, nil
-				}
-				return m.PlaySelectedMusic(types.PlaylistTrackObject{
-					Track: types.Track{
-						ID:   ep.ID,
-						Name: ep.TitleName,
-						Artists: []types.Artist{
-							{Name: ep.PodcastName},
-						},
-					},
-				})
-			}
-		}
-	}
 	return m, nil
+}
+
+func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
+	if m.MainViewMode == HomePageMode && m.FocusedOn == MainView {
+		return m.handleHomePageEnter()
+	}
+
+	listItemToChooseMusicFrom := getListItemForMusicToChoose(&m, m.FocusedOn)
+	if listItemToChooseMusicFrom == nil {
+		return m, nil
+	}
+
+	switch selectedItem := listItemToChooseMusicFrom.SelectedItem().(type) {
+	case types.PlaylistTrackObject:
+		return m.playTrackFromList(selectedItem, m.SelectedPlayListItems.Items())
+
+	case types.Playlist:
+		return m.navigateToDetailView(m.getPlaylistItems(selectedItem.ID))
+
+	case types.Album:
+		return m.navigateToDetailView(m.getAlbumTracks(selectedItem.ID))
+
+	case types.Artist:
+		return m.navigateToDetailView(m.getArtistTracks(selectedItem.ID))
+
+	case types.Podcast:
+		return m.navigateToDetailView(m.getPlaylistItems(selectedItem.ID))
+
+	case types.Episode:
+		return m.PlaySelectedMusic(types.PlaylistTrackObject{
+			Track: types.Track{
+				ID:   selectedItem.ID,
+				Name: selectedItem.TitleName,
+				Artists: []types.Artist{
+					{Name: selectedItem.PodcastName},
+				},
+			},
+		})
+	case types.HomePageContentItem:
+		if selectedItem.VideoID != "" || selectedItem.ContentType == "song" || selectedItem.ContentType == "video" {
+			trackID := selectedItem.VideoID
+			if trackID == "" {
+				trackID = selectedItem.PlaylistID
+			}
+			playlistTrack := types.PlaylistTrackObject{
+				Track: types.Track{
+					ID:   trackID,
+					Name: selectedItem.ItemTitle,
+				},
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			relatedSongsCmd := func() tea.Msg {
+				relatedSongs, err := m.YtMusicClient.GetSongRelated(ctx, &musicpb.GetSongRelatedRequest{
+					BrowseId: playlistTrack.Track.ID,
+				})
+				return types.RelatedSongsMsg{
+					Related: relatedSongs,
+					Err:     err,
+				}
+			}
+			m, cmd := m.PlaySelectedMusic(playlistTrack)
+			return m, tea.Batch(cmd, relatedSongsCmd)
+		} else if selectedItem.ContentType == "album" || strings.HasPrefix(selectedItem.BrowseID, "MPRE") {
+			browseID := selectedItem.BrowseID
+			if browseID == "" {
+				browseID = selectedItem.PlaylistID
+			}
+			return m.navigateToDetailView(m.getAlbumTracks(browseID))
+		} else if selectedItem.PlaylistID != "" || selectedItem.BrowseID != "" {
+			playlistID := selectedItem.PlaylistID
+			if playlistID == "" {
+				playlistID = selectedItem.BrowseID
+			}
+			return m.navigateToDetailView(m.getPlaylistItems(playlistID))
+		}
+	case types.SearchResultItem:
+		if selectedItem.Kind() == types.SearchResultTrack {
+			track, ok := selectedItem.(types.Track)
+			if !ok {
+				slog.Error("failed to cast the selected item to types.Track")
+				return m, nil
+			}
+			relatedSongsCmd := func() tea.Msg {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				relatedSongs, err := m.YtMusicClient.GetSongRelated(ctx, &musicpb.GetSongRelatedRequest{
+					BrowseId: track.ID,
+				})
+				return types.RelatedSongsMsg{
+					Related: relatedSongs,
+					Err:     err,
+				}
+			}
+			m, cmd := m.PlaySelectedMusic(types.PlaylistTrackObject{
+				Track: track,
+			})
+			return m, tea.Batch(cmd, relatedSongsCmd)
+		}
+	}
+
+	return m, nil
+}
+
+func (m Model) handleSearchBarEnter() (Model, tea.Cmd) {
+	query := m.Search.Value()
+	if query == m.SearchQuery && len(m.SearchResult.Items()) > 0 {
+		m.MainViewMode = SearchResultMode
+		return m, nil
+	}
+
+	loadingCmd := SendLoadingCmd()
+	searchingCmd := func() tea.Msg {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		searchResults, err := m.YtMusicClient.GetSearchResults(ctx, &musicpb.GetSearchResultsRequest{
+			Query: query,
+		})
+
+		if err != nil {
+			slog.Error(err.Error())
+			return types.SpotifySearchResultMsg{
+				Result: nil,
+				Err:    err,
+			}
+		}
+
+		var items []list.Item
+		for _, s := range searchResults.Songs {
+			track := types.MapSearchResultSongToTrack(s)
+			items = append(items, track)
+		}
+		for _, a := range searchResults.Artists {
+			artist := types.Artist{
+				ID:     a.BrowseId,
+				Name:   a.Name,
+				Images: types.MapThumbnailsToImages(a.Thumbnails),
+			}
+			items = append(items, artist)
+		}
+		for _, p := range searchResults.Playlists {
+			playlist := types.Playlist{
+				ID:          p.BrowseId,
+				Name:        p.Title,
+				Description: p.ItemCount,
+				Images:      types.MapThumbnailsToImages(p.Thumbnails),
+				Author:      p.Author,
+			}
+			items = append(items, playlist)
+		}
+		for _, al := range searchResults.Albums {
+			album := types.Album{
+				ID:      al.BrowseId,
+				Name:    al.Title,
+				Artists: types.MapArtistsToArtists(al.Artists),
+				Images:  types.MapThumbnailsToImages(al.Thumbnails),
+				Year:    al.Year,
+				Type:    al.Type,
+			}
+			items = append(items, album)
+		}
+		for _, pod := range searchResults.Podcasts {
+			podcast := types.Podcast{
+				ID:     pod.BrowseId,
+				Name:   pod.Title,
+				Author: pod.Author,
+				Images: types.MapThumbnailsToImages(pod.Thumbnails),
+			}
+			items = append(items, podcast)
+		}
+		for _, ep := range searchResults.Episodes {
+			episode := types.Episode{
+				ID:          ep.VideoId,
+				TitleName:   ep.Title,
+				PodcastName: ep.PodcastName,
+				PodcastID:   ep.PodcastId,
+				Date:        ep.Date,
+				Images:      types.MapThumbnailsToImages(ep.Thumbnails),
+			}
+			items = append(items, episode)
+		}
+
+		searchResult := &types.SearchResponse{
+			Items: items,
+		}
+
+		return types.SpotifySearchResultMsg{
+			Result: searchResult,
+			Err:    nil,
+		}
+	}
+	m.SearchQuery = query
+	return m, tea.Batch(loadingCmd, searchingCmd)
 }
 
 func (m Model) getArtistTracks(artistID string) tea.Cmd {
@@ -1296,34 +1267,6 @@ func (m Model) getAlbumTracks(albumID string) tea.Cmd {
 		return types.UpdatePlaylistMsg{
 			Playlist: tracks,
 			Err:      nil,
-		}
-	}
-}
-
-func (m Model) getUserSavedTracks() tea.Cmd {
-	return func() tea.Msg {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		savedTracks, err := m.YtMusicClient.GetUserSavedTracks(ctx, &musicpb.GetUserSavedTracksRequest{
-			Limit: 100,
-		})
-		if err != nil {
-			slog.Error(err.Error())
-			return types.UpdatePlaylistMsg{
-				Playlist: nil,
-				Err:      err,
-			}
-		}
-		var tracks []*types.PlaylistTrackObject
-		for _, track := range savedTracks.Tracks {
-			tracks = append(tracks, &types.PlaylistTrackObject{
-				Track: types.MapSongToTrack(track),
-			})
-		}
-		return types.UpdatePlaylistMsg{
-			Playlist:     tracks,
-			Err:          nil,
-			ShouldAppend: false,
 		}
 	}
 }
@@ -1388,7 +1331,19 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 		return getStreamURLResponse, nil
 	})
 
-	cmds = append(cmds, cmd)
+	lyricsCmd := func() tea.Msg {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		lyricsResponse, err := m.YtMusicClient.GetLyrics(ctx, &musicpb.GetLyricsRequest{
+			BrowseId: selectedMusic.Track.ID,
+		})
+		return types.LyricsMsg{
+			LyricsResponse: lyricsResponse,
+			Err:            err,
+		}
+	}
+
+	cmds = append(cmds, cmd, lyricsCmd)
 	metadata := getMusicMetadata(MusicMetadata{
 		artistName: strings.Join(artistNames, ","),
 		length:     int64(selectedMusic.Track.DurationMS),
@@ -1477,6 +1432,7 @@ func updateDelegate(m *Model) {
 	m.SideBarList.SetDelegate(CustomDelegate{Model: m})
 	m.HomePageList.SetDelegate(CustomDelegate{Model: m})
 	m.SearchResult.SetDelegate(CustomDelegate{Model: m})
+	m.RelatedList.SetDelegate(CustomDelegate{Model: m})
 }
 
 func updateFocusedComponent(m *Model, msg tea.Msg, cmdsFromParent *[]tea.Cmd) (Model, tea.Cmd) {
@@ -1494,7 +1450,9 @@ func updateFocusedComponent(m *Model, msg tea.Msg, cmdsFromParent *[]tea.Cmd) (M
 		cmds = append(cmds, cmd)
 	case QueueList:
 		var cmd tea.Cmd
-		if m.MusicQueueList != nil {
+		if len(m.RelatedList.Items()) > 0 {
+			m.RelatedList, cmd = m.RelatedList.Update(msg)
+		} else if m.MusicQueueList != nil {
 			m.MusicQueueList.Model, cmd = m.MusicQueueList.Model.Update(msg)
 		}
 		cmds = append(cmds, cmd)

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/godbus/dbus/v5"
 	musicpb "github.com/kumneger0/clispot/gen"
 	"github.com/kumneger0/clispot/internal/types"
@@ -275,8 +276,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.LibraryWidth = dims.sidebarWidth
 		m.MainViewWidth = dims.mainWidth
 		m.PlayerSectionHeight = dims.inputHeight
-		m.LyricsView.Width = dims.mainWidth
-		m.LyricsView.Height = dims.contentHeight
+		m.LyricsView.Width = max(dims.mainWidth-6, 10)
+		m.LyricsView.Height = max(dims.contentHeight-6, 10)
 		return m, nil
 	case types.UpdatePlaylistMsg:
 		if msg.Playlist != nil {
@@ -346,6 +347,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.RelatedList = list.New(items, CustomDelegate{Model: &m}, width, m.Height)
 		removeListDefaults(&m.RelatedList)
 		m.RelatedList.Title = "Related"
+		return m, nil
+	case types.LyricsMsg:
+		if msg.Err != nil || msg.LyricsResponse == nil {
+			noLyricsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
+			m.LyricsView.SetContent(noLyricsStyle.Render("No lyrics found for this song."))
+			return m, nil
+		}
+		var lyricsText string
+		if msg.LyricsResponse.HasTimestamps && len(msg.LyricsResponse.Lines) > 0 {
+			var lines []string
+			for _, line := range msg.LyricsResponse.Lines {
+				lines = append(lines, line.Text)
+			}
+			lyricsText = strings.Join(lines, "\n")
+		} else if msg.LyricsResponse.Lyrics != "" {
+			lyricsText = msg.LyricsResponse.Lyrics
+		} else {
+			noLyricsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
+			lyricsText = noLyricsStyle.Render("No lyrics available for this song.")
+		}
+		if msg.LyricsResponse.Source != "" {
+			sourceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
+			lyricsText = lyricsText + "\n\n" + sourceStyle.Render(msg.LyricsResponse.Source)
+		}
+		m.LyricsView.SetContent(lyricsText)
 		return m, nil
 	case tea.KeyMsg:
 		model, cmd := m.handleKeyPress(msg)
@@ -421,6 +447,11 @@ func (m Model) handlePagination(listModel *list.Model, ShouldAppendQueue bool, c
 func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 	switch msg.String() {
 	case "down", "j":
+		if m.MainViewMode == LyricsMode && m.FocusedOn == MainView {
+			var cmd tea.Cmd
+			m.LyricsView, cmd = m.LyricsView.Update(msg)
+			return m, cmd
+		}
 		if m.FocusedOn != MainView && m.FocusedOn != QueueList {
 			return m, nil
 		}
@@ -432,6 +463,11 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 		listModel := getListItemForMusicToChoose(&m, m.FocusedOn)
 		return m.handlePagination(listModel, m.FocusedOn == QueueList, nil)
 	case "up", "k":
+		if m.MainViewMode == LyricsMode && m.FocusedOn == MainView {
+			var cmd tea.Cmd
+			m.LyricsView, cmd = m.LyricsView.Update(msg)
+			return m, cmd
+		}
 		if m.FocusedOn != MainView && m.FocusedOn != QueueList {
 			return m, nil
 		}
@@ -605,7 +641,12 @@ func getNextPageItems(m *Model, paginationInfo *types.PaginationInfo, ShouldAppe
 	return nil
 }
 func (m Model) getMusicLyrics(track *SelectedTrack) (Model, tea.Cmd) {
-	//TODO: implement lyrics later
+	if m.MainViewMode == LyricsMode {
+		m.MainViewMode = NormalMode
+	} else {
+		m.MainViewMode = LyricsMode
+		m.FocusedOn = MainView
+	}
 	return m, nil
 }
 
@@ -1330,6 +1371,8 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 		}
 		return getStreamURLResponse, nil
 	})
+
+	m.LyricsView.SetContent("  ⟳ Loading lyrics...")
 
 	lyricsCmd := func() tea.Msg {
 		ctx, cancel := context.WithCancel(context.Background())

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -261,6 +261,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.PlayedSeconds = msg.CurrentSeconds
+		if m.CurrentLyrics != nil {
+			m.updateLyricsView()
+		}
 		totalDurationInSeconds := m.SelectedTrack.Track.Track.DurationMS / 1000
 		if totalDurationInSeconds > 0 && (float64(totalDurationInSeconds)-m.PlayedSeconds) < 1 {
 			m.PlayedSeconds = 0
@@ -322,7 +325,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, alertCmd)
 		}
 	case types.RelatedSongsMsg:
-		if msg.Err != nil || msg.Related == nil || len(msg.Related.Sections) == 0 {
+		if msg.Err != nil {
+			slog.Error(msg.Err.Error())
+			alertCmd := m.Alert.NewAlertCmd(bubbleup.ErrorKey, msg.Err.Error())
+			cmds = append(cmds, alertCmd)
+		}
+		if msg.Related == nil || len(msg.Related.Sections) == 0 {
+			slog.Error("Failed to Fetch Related Songs")
 			return m, nil
 		}
 		var items []list.Item
@@ -350,29 +359,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.RightColumnMode = RightColumnRelated
 		return m, nil
 	case types.LyricsMsg:
-		if msg.Err != nil || msg.LyricsResponse == nil {
+		if msg.Err != nil {
+			alertCmd := m.Alert.NewAlertCmd(bubbleup.ErrorKey, msg.Err.Error())
+			slog.Error(msg.Err.Error())
+			m.LyricsView.SetContent(msg.Err.Error())
+			return m, alertCmd
+		}
+		if msg.LyricsResponse == nil {
 			noLyricsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
 			m.LyricsView.SetContent(noLyricsStyle.Render("No lyrics found for this song."))
+			m.CurrentLyrics = nil
 			return m, nil
 		}
-		var lyricsText string
-		if msg.LyricsResponse.HasTimestamps && len(msg.LyricsResponse.Lines) > 0 {
-			var lines []string
-			for _, line := range msg.LyricsResponse.Lines {
-				lines = append(lines, line.Text)
-			}
-			lyricsText = strings.Join(lines, "\n")
-		} else if msg.LyricsResponse.Lyrics != "" {
-			lyricsText = msg.LyricsResponse.Lyrics
-		} else {
-			noLyricsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
-			lyricsText = noLyricsStyle.Render("No lyrics available for this song.")
-		}
-		if msg.LyricsResponse.Source != "" {
-			sourceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
-			lyricsText = lyricsText + "\n\n" + sourceStyle.Render(msg.LyricsResponse.Source)
-		}
-		m.LyricsView.SetContent(lyricsText)
+		m.CurrentLyrics = msg.LyricsResponse
+		m.updateLyricsView()
 		return m, nil
 	case tea.KeyMsg:
 		model, cmd := m.handleKeyPress(msg)
@@ -499,9 +499,16 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case "a":
 		return m.addMusicToQueue()
 	case "r":
-		if m.FocusedOn == QueueList && m.MusicQueueList != nil {
-			if len(m.MusicQueueList.Model.Items()) > 0 {
-				m.MusicQueueList.Model.RemoveItem(m.MusicQueueList.GlobalIndex())
+		if m.FocusedOn == QueueList {
+			showRelated := (m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "") && len(m.RelatedList.Items()) > 0
+			if showRelated {
+				if len(m.RelatedList.Items()) > 0 {
+					m.RelatedList.RemoveItem(m.RelatedList.Index())
+				}
+			} else if m.MusicQueueList != nil {
+				if len(m.MusicQueueList.Model.Items()) > 0 {
+					m.MusicQueueList.Model.RemoveItem(m.MusicQueueList.GlobalIndex())
+				}
 			}
 		}
 	case "ctrl+l":
@@ -553,22 +560,10 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 		}
 		return m.handleMusicChange(true)
 	case "ctrl+q", "t":
-		if m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "" {
-			m.RightColumnMode = RightColumnQueue
-		} else {
-			m.RightColumnMode = RightColumnRelated
-		}
+		m.toggleRightColumnMode()
 		return m, nil
 	case "q", "ctrl+c":
 		if m.FocusedOn == SearchBar {
-			return m, nil
-		}
-		if msg.String() == "q" && m.FocusedOn == QueueList && len(m.RelatedList.Items()) > 0 {
-			if m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "" {
-				m.RightColumnMode = RightColumnQueue
-			} else {
-				m.RightColumnMode = RightColumnRelated
-			}
 			return m, nil
 		}
 		if m.BackendProcess != nil && m.BackendProcess.Process != nil {
@@ -664,6 +659,83 @@ func (m Model) getMusicLyrics(track *SelectedTrack) (Model, tea.Cmd) {
 		m.FocusedOn = MainView
 	}
 	return m, nil
+}
+
+func (m *Model) toggleRightColumnMode() {
+	if m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "" {
+		m.RightColumnMode = RightColumnQueue
+		if m.MusicQueueList != nil && len(m.MusicQueueList.Model.Items()) > 0 {
+			m.MusicQueueList.Model.Select(0)
+		}
+	} else {
+		m.RightColumnMode = RightColumnRelated
+		if len(m.RelatedList.Items()) > 0 {
+			m.RelatedList.Select(0)
+		}
+	}
+}
+
+func (m *Model) updateLyricsView() {
+	if m.CurrentLyrics == nil {
+		return
+	}
+
+	activeStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#A855F7"))
+	inactiveStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#A1A1AA"))
+	sourceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
+
+	if m.CurrentLyrics.HasTimestamps && len(m.CurrentLyrics.Lines) > 0 {
+		currentMS := int32(m.PlayedSeconds*1000) - 750
+		if currentMS < 0 {
+			currentMS = 0
+		}
+		activeIdx := -1
+
+		for i, line := range m.CurrentLyrics.Lines {
+			if line.StartTime <= currentMS {
+				activeIdx = i
+			} else {
+				break
+			}
+		}
+
+		if activeIdx < 0 && len(m.CurrentLyrics.Lines) > 0 {
+			activeIdx = 0
+		}
+
+		var lines []string
+		for i, line := range m.CurrentLyrics.Lines {
+			if i == activeIdx {
+				lines = append(lines, activeStyle.Render("▶ "+line.Text))
+			} else {
+				lines = append(lines, inactiveStyle.Render("  "+line.Text))
+			}
+		}
+
+		lyricsText := strings.Join(lines, "\n")
+		if m.CurrentLyrics.Source != "" {
+			lyricsText = lyricsText + "\n\n" + sourceStyle.Render(m.CurrentLyrics.Source)
+		}
+
+		m.LyricsView.SetContent(lyricsText)
+
+		if activeIdx >= 0 && m.LyricsView.Height > 0 {
+			targetOffset := activeIdx - (m.LyricsView.Height / 2)
+			if targetOffset < 0 {
+				targetOffset = 0
+			}
+			m.LyricsView.SetYOffset(targetOffset)
+		}
+	} else if m.CurrentLyrics.Lyrics != "" {
+		lyricsText := m.CurrentLyrics.Lyrics
+		if m.CurrentLyrics.Source != "" {
+			lyricsText = lyricsText + "\n\n" + sourceStyle.Render(m.CurrentLyrics.Source)
+		}
+		m.LyricsView.SetContent(lyricsText)
+	} else {
+		noLyricsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
+		m.LyricsView.SetContent(noLyricsStyle.Render("No lyrics available for this song."))
+	}
 }
 
 func (m Model) handleMusicChange(isForward bool) (Model, tea.Cmd) {
@@ -1094,14 +1166,14 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			relatedSongs, err := m.YtMusicClient.GetSongRelated(ctx, &musicpb.GetSongRelatedRequest{
-				BrowseId: selectedItem.Track.ID,
+				VideoId: selectedItem.Track.ID,
 			})
 			return types.RelatedSongsMsg{
 				Related: relatedSongs,
 				Err:     err,
 			}
 		}
-		m, cmd := m.playTrackFromList(selectedItem, m.SelectedPlayListItems.Items())
+		m, cmd := m.playTrackFromList(selectedItem, listItemToChooseMusicFrom.Items())
 		return m, tea.Batch(cmd, relatedSongsCmd)
 
 	case types.Playlist:
@@ -1143,7 +1215,7 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				relatedSongs, err := m.YtMusicClient.GetSongRelated(ctx, &musicpb.GetSongRelatedRequest{
-					BrowseId: playlistTrack.Track.ID,
+					VideoId: playlistTrack.Track.ID,
 				})
 				return types.RelatedSongsMsg{
 					Related: relatedSongs,
@@ -1176,7 +1248,7 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				relatedSongs, err := m.YtMusicClient.GetSongRelated(ctx, &musicpb.GetSongRelatedRequest{
-					BrowseId: track.ID,
+					VideoId: track.ID,
 				})
 				return types.RelatedSongsMsg{
 					Related: relatedSongs,
@@ -1399,13 +1471,15 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 		return getStreamURLResponse, nil
 	})
 
+	m.CurrentLyrics = nil
 	m.LyricsView.SetContent("  ⟳ Loading lyrics...")
 
 	lyricsCmd := func() tea.Msg {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		lyricsResponse, err := m.YtMusicClient.GetLyrics(ctx, &musicpb.GetLyricsRequest{
-			BrowseId: selectedMusic.Track.ID,
+			VideoId:    selectedMusic.Track.ID,
+			Timestamps: true,
 		})
 		return types.LyricsMsg{
 			LyricsResponse: lyricsResponse,
@@ -1445,11 +1519,6 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 		Track:   &selectedMusic,
 	}
 
-	if m.MainViewMode == LyricsMode {
-		model, cmd := m.getMusicLyrics(m.SelectedTrack)
-		m = model
-		cmds = append(cmds, cmd)
-	}
 	return m, tea.Batch(cmds...)
 }
 

--- a/proto/music.proto
+++ b/proto/music.proto
@@ -34,6 +34,8 @@ service MusicService {
   rpc GetVideoStreamURLAndDuration(GetVideoStreamURLAndDurationRequest) returns (GetVideoStreamURLAndDurationResponse);
 
   rpc GetHomePage(GetHomePageRequest) returns (GetHomePageResponse);
+  rpc GetSongRelated(GetSongRelatedRequest) returns (GetSongRelatedResponse);
+  rpc GetLyrics(GetLyricsRequest) returns (GetLyricsResponse);
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
 }
 
@@ -366,4 +368,53 @@ message GetVideoStreamURLAndDurationRequest {
 message GetVideoStreamURLAndDurationResponse {
   string url = 1;
   string duration = 2;
+}
+
+message GetSongRelatedRequest {
+  string browse_id = 1;
+}
+
+message GetSongRelatedResponse {
+  repeated SongRelatedSection sections = 1;
+}
+
+message SongRelatedSection {
+  string title = 1;
+  repeated SongRelatedContent contents = 2;
+  string text_content = 3;
+}
+
+message SongRelatedContent {
+  string title = 1;
+  string video_id = 2;
+  string playlist_id = 3;
+  string browse_id = 4;
+  repeated Artist artists = 5;
+  repeated Thumbnail thumbnails = 6;
+  bool is_explicit = 7;
+  string album = 8;
+  string album_id = 9;
+  string description = 10;
+  string subscribers = 11;
+  string year = 12;
+  string content_type = 13;
+}
+
+message GetLyricsRequest {
+  string browse_id = 1;
+  bool timestamps = 2;
+}
+
+message LyricLine {
+  string text = 1;
+  int32 start_time = 2;
+  int32 end_time = 3;
+  int32 id = 4;
+}
+
+message GetLyricsResponse {
+  string lyrics = 1;
+  string source = 2;
+  bool has_timestamps = 3;
+  repeated LyricLine lines = 4;
 }

--- a/proto/music.proto
+++ b/proto/music.proto
@@ -371,7 +371,7 @@ message GetVideoStreamURLAndDurationResponse {
 }
 
 message GetSongRelatedRequest {
-  string browse_id = 1;
+  string videoId = 1;
 }
 
 message GetSongRelatedResponse {
@@ -401,7 +401,7 @@ message SongRelatedContent {
 }
 
 message GetLyricsRequest {
-  string browse_id = 1;
+  string videoId = 1;
   bool timestamps = 2;
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,6 @@ dev = [
 ]
 
 [tool.basedpyright]
-typeCheckingMode = "strict"
+typeCheckingMode = "standard"
+exclude = ["grpc_server/gen"]
 extraPaths = ["grpc_server/gen"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added related-song recommendations in a dedicated right panel (tracks, albums, artists, and playlists).
  * Added a lyrics view with optional timestamps, including a “loading” state and a track name header when available.
  * Integrated fetching related songs and lyrics from search/home selections; added right-column navigation between queue and related content (including a queue/related keybind).

* **Bug Fixes**
  * Improved robustness when mapping heterogeneous runtime data for search, home sections, podcasts, authors, thumbnails, and durations.
  * Added safer error handling for related-content and lyrics requests, returning empty results on failures.

* **Documentation / Chores**
  * Relaxed Python type-checking strictness and excluded generated gRPC code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->