### PR TITLE
fix: dont treat artist as playlist

### DIFF
--- a/grpc_server/main.py
+++ b/grpc_server/main.py
@@ -213,12 +213,12 @@ def to_proto_song_related_content(content: dict[str, Any]) -> music_pb2.SongRela
     content_type = ""
     if content.get("videoId"):
         content_type = "song"
+    elif content.get("subscribers") or (content.get("browseId") and str(content.get("browseId")).startswith("UC")):
+        content_type = "artist"
     elif content.get("playlistId"):
         content_type = "playlist"
-    elif content.get("subscribers"):
-        content_type = "artist"
     elif content.get("browseId"):
-        if str(content.get("browseId")).startswith("MPRE"):
+        if str(content.get("browseId")).startswith("MPRE") or str(content.get("browseId")).startswith("FEmusic_album"):
             content_type = "album"
         else:
             content_type = "artist"

--- a/internal/ui/renderers.go
+++ b/internal/ui/renderers.go
@@ -175,6 +175,8 @@ func (d CustomDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 		if item.SongRelatedContent != nil {
 			if item.VideoId != "" || item.ContentType == "song" || item.ContentType == "video" {
 				icon = "♫"
+			} else if item.ContentType == "artist" || strings.HasPrefix(item.BrowseId, "UC") || item.Subscribers != "" {
+				icon = "♪"
 			} else if item.ContentType == "album" || strings.HasPrefix(item.BrowseId, "MPRE") {
 				icon = "◉"
 			} else {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1261,10 +1261,16 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 			}
 			m, cmd := m.PlaySelectedMusic(playlistTrack)
 			return m, tea.Batch(cmd, relatedSongsCmd)
+		} else if selectedItem.ContentType == "artist" || strings.HasPrefix(selectedItem.BrowseId, "UC") || selectedItem.Subscribers != "" {
+			return m.navigateToDetailView(m.getArtistTracks(selectedItem.BrowseId))
 		} else if selectedItem.ContentType == "album" || strings.HasPrefix(selectedItem.BrowseId, "MPRE") {
 			return m.navigateToDetailView(m.getAlbumTracks(selectedItem.BrowseId))
-		} else if selectedItem.PlaylistId != "" || selectedItem.ContentType == "playlist" {
-			return m.navigateToDetailView(m.getPlaylistItems(selectedItem.PlaylistId))
+		} else if selectedItem.ContentType == "playlist" || (selectedItem.PlaylistId != "" && selectedItem.ContentType == "") {
+			playlistID := selectedItem.PlaylistId
+			if playlistID == "" {
+				playlistID = selectedItem.BrowseId
+			}
+			return m.navigateToDetailView(m.getPlaylistItems(playlistID))
 		} else if selectedItem.BrowseId != "" {
 			return m.navigateToDetailView(m.getArtistTracks(selectedItem.BrowseId))
 		}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -414,3 +414,25 @@ func TestUpdate_SearchBar_FocusSubmitCancel(t *testing.T) {
 		t.Errorf("FocusedOn after escape: should not be SearchBar, got %s", updatedCancel.FocusedOn)
 	}
 }
+
+func TestUpdate_SongRelatedContent_ArtistSelection(t *testing.T) {
+	m := newTestModel()
+	m.FocusedOn = QueueList
+	m.RightColumnMode = RightColumnRelated
+
+	artistItem := types.SongRelatedContentItem{
+		SongRelatedContent: &musicpb.SongRelatedContent{
+			Title:       "Kendrick Lamar",
+			BrowseId:    "UCq3V-gFmAdGlc8c-1M8-g",
+			ContentType: "artist",
+			Subscribers: "10M",
+		},
+	}
+
+	m.RelatedList = list.New([]list.Item{artistItem}, CustomDelegate{Model: &m}, 20, 10)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Error("cmd should not be nil when selecting related artist")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of artist and album entries in song-related content.
  * Updated related-content icons to display artist artwork for artist entries.
  * Improved navigation to artists, albums, and playlists from related-content results.
  * Added support for playlist identifier fallbacks.

* **Tests**
  * Added coverage for selecting an artist with the Enter key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->