### PR TITLE
fix: reset ytmusic client instace on exepection due to subsequent request failure

### DIFF
--- a/grpc_server/main.py
+++ b/grpc_server/main.py
@@ -686,6 +686,8 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
         context: grpc.ServicerContext,
     ) -> music_pb2.GetSongRelatedResponse:
         try:
+            if not request.videoId and not getattr(request, "browse_id", None):
+                return music_pb2.GetSongRelatedResponse()
             browse_id = getattr(request, "browse_id", None) or getattr(request, "videoId", None)
             if not browse_id or not browse_id.startswith("MPTRt_"):
                 watch_data = self.client.get_watch_playlist(request.videoId)
@@ -693,7 +695,7 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 if isinstance(related_id, str) and related_id:
                     browse_id = related_id
 
-            if browse_id is None:
+            if not browse_id or not browse_id.startswith("MPTRt_"):
                 return music_pb2.GetSongRelatedResponse()
 
             sections_data = self.client.get_song_related(browse_id)
@@ -702,6 +704,7 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
                 sec_msg = music_pb2.SongRelatedSection(
                     title=str(section.get("title") or "")
                 )
+                
                 contents_data = section.get("contents")
                 if isinstance(contents_data, str):
                     sec_msg.text_content = contents_data
@@ -712,8 +715,6 @@ class MusicService(music_pb2_grpc.MusicServiceServicer): # type: ignore
             return response
         except Exception as e:
             print(f"Error in GetSongRelated: {e}")
-            context.set_code(grpc.StatusCode.INTERNAL)
-            context.set_details(str(e))
             return music_pb2.GetSongRelatedResponse()
 
     @override

--- a/grpc_server/src/client/client.py
+++ b/grpc_server/src/client/client.py
@@ -29,6 +29,7 @@ class MusicClient:
         self.auth_file = auth_file
         self._client: YTMusic | None = None
         self._lock = threading.Lock()
+        self._generation = 0
 
     def get_client(self) -> YTMusic:
         if self._client is None:
@@ -42,22 +43,27 @@ class MusicClient:
         if self.auth_file:
             try:
                 self._client = YTMusic(auth=self.auth_file)
+                self._generation += 1
                 return
             except Exception as e:
                 print(f"Error initializing YTMusic with auth_file {self.auth_file}: {e}")
         self._client = YTMusic()
+        self._generation += 1
 
-    def reset_client(self) -> None:
+    def reset_client(self, known_generation: int | None = None) -> None:
         with self._lock:
+            if known_generation is not None and known_generation != self._generation:
+                return  # Another thread already reset the client for this failure.
             print("Resetting YTMusic client due to error/session corruption...")
             self._init_client()
 
     def execute(self, func: Callable[[YTMusic], T]) -> T:
+        generation = self._generation
         try:
             return func(self.get_client())
         except Exception as e:
             print(f"YTMusic request execution failed ({e}). Resetting client and retrying once...")
-            self.reset_client()
+            self.reset_client(known_generation=generation)
             return func(self.get_client())
     def get_stream_url_and_duration(self, video_id:str)  -> GetStreamURLResponse:
         full_url: str = "https://www.youtube.com/watch?v=" + video_id
@@ -122,15 +128,19 @@ class MusicClient:
             video_details = song_dict.get("videoDetails")
             if not isinstance(video_details, dict):
                 return cast(YTSongResponse, cast(object, {}))
-            track: YTSongResponse = cast(YTSongResponse, cast(object, video_details))
-            track_video_id = track.get("videoId")
-            if isinstance(track_video_id, str):
+            return cast(YTSongResponse, cast(object, video_details))
+
+        track = self.execute(_fetch)
+        track_video_id = track.get("videoId")
+        if isinstance(track_video_id, str):
+            try:
                 stream_url_and_duration = self.get_stream_url_and_duration(video_id=track_video_id)
                 track["url"] = stream_url_and_duration.get("url")
                 if stream_url_and_duration.get("duration") is not None:
                     track["lengthSeconds"] = str(stream_url_and_duration.get("duration"))
-            return track
-        return self.execute(_fetch)
+            except Exception as e:
+                print(f"Error extracting stream url for track {track_video_id}: {e}")
+        return track
 
     def get_album_tracks(self, browse_id: str) -> YTAlbumResponse:
         return self.execute(lambda c: cast(YTAlbumResponse, cast(object, c.get_album(browseId=browse_id))))
@@ -194,12 +204,13 @@ class MusicClient:
                 res = self.execute(lambda c: c.get_lyrics(browseId=browse_id, timestamps=True))
                 if res and (isinstance(res, dict) and (res.get("hasTimestamps") or res.get("lyrics"))):
                     return cast(dict[str, Any], res)
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"Failed to fetch timed lyrics via web API: {e}")
 
         try:
             return self.execute(lambda c: c.get_lyrics(browseId=browse_id, timestamps=False))
-        except Exception:
+        except Exception as e:
+            print(f"Failed to fetch plain lyrics: {e}")
             return None
 
     def _get_timed_lyrics_raw(self, browse_id: str) -> TimedLyrics | None:

--- a/grpc_server/src/client/client.py
+++ b/grpc_server/src/client/client.py
@@ -1,7 +1,10 @@
-from typing import cast, Any
+import threading
+from typing import cast, Any, Callable, TypeVar
 from ytmusicapi.models.lyrics import Lyrics, TimedLyrics
-from ytmusicapi import  YTMusic, LikeStatus
+from ytmusicapi import YTMusic, LikeStatus
 from yt_dlp import YoutubeDL
+
+T = TypeVar("T")
 
 from .types import (
     GetStreamURLResponse,
@@ -22,13 +25,40 @@ from .types import (
 )
 
 class MusicClient:
-    client: YTMusic
+    def __init__(self, auth_file: str | None = None) -> None:
+        self.auth_file = auth_file
+        self._client: YTMusic | None = None
+        self._lock = threading.Lock()
 
-    def __init__(self, auth_file: str) -> None:
+    def get_client(self) -> YTMusic:
+        if self._client is None:
+            with self._lock:
+                if self._client is None:
+                    self._init_client()
+        assert self._client is not None
+        return self._client
+
+    def _init_client(self) -> None:
+        if self.auth_file:
+            try:
+                self._client = YTMusic(auth=self.auth_file)
+                return
+            except Exception as e:
+                print(f"Error initializing YTMusic with auth_file {self.auth_file}: {e}")
+        self._client = YTMusic()
+
+    def reset_client(self) -> None:
+        with self._lock:
+            print("Resetting YTMusic client due to error/session corruption...")
+            self._init_client()
+
+    def execute(self, func: Callable[[YTMusic], T]) -> T:
         try:
-            self.client = YTMusic(auth=auth_file)
-        except Exception:
-            self.client =YTMusic()
+            return func(self.get_client())
+        except Exception as e:
+            print(f"YTMusic request execution failed ({e}). Resetting client and retrying once...")
+            self.reset_client()
+            return func(self.get_client())
     def get_stream_url_and_duration(self, video_id:str)  -> GetStreamURLResponse:
         full_url: str = "https://www.youtube.com/watch?v=" + video_id
         options = {
@@ -51,144 +81,136 @@ class MusicClient:
         }
 
     def get_home(self) -> list[YTHomeSection]:
-        res: object = self.client.get_home(limit=10)
-        return cast(list[YTHomeSection], res)
+        return self.execute(lambda c: cast(list[YTHomeSection], c.get_home(limit=10)))
 
     def get_library(self, limit: int = 25) -> YTLibraryResponse:
-        albums = cast(list[YTLibraryAlbum], self.client.get_library_albums(limit))
-        playlists = cast(list[YTLibraryPlaylist], self.client.get_library_playlists(limit))
-        channels = cast(list[YTLibraryChannel], self.client.get_library_channels(limit))
-        artists = cast(list[YTLibraryArtist], self.client.get_library_subscriptions(limit))
-        podcasts = cast(list[YTLibraryPlaylist], self.client.get_library_podcasts(limit))
-        return {
-            "albums": albums,
-            "playlists": playlists,
-            "channels": channels,
-            "artists": artists,
-            "podcasts": podcasts,
-        }
-    
+        def _fetch(c: YTMusic) -> YTLibraryResponse:
+            albums = cast(list[YTLibraryAlbum], c.get_library_albums(limit))
+            playlists = cast(list[YTLibraryPlaylist], c.get_library_playlists(limit))
+            channels = cast(list[YTLibraryChannel], c.get_library_channels(limit))
+            artists = cast(list[YTLibraryArtist], c.get_library_subscriptions(limit))
+            podcasts = cast(list[YTLibraryPlaylist], c.get_library_podcasts(limit))
+            return {
+                "albums": albums,
+                "playlists": playlists,
+                "channels": channels,
+                "artists": artists,
+                "podcasts": podcasts,
+            }
+        return self.execute(_fetch)
 
     def get_user_saved_tracks(self, limit: int = 100) -> list[YTSong]:
-        raw_songs: object = self.client.get_liked_songs(limit)
-        songs = cast(YTLikedSongsResponse, cast(object, raw_songs))
-        tracks = songs.get('tracks')
-        if isinstance(tracks, list):
-            return tracks
-        return []
+        def _fetch(c: YTMusic) -> list[YTSong]:
+            raw_songs: object = c.get_liked_songs(limit)
+            songs = cast(YTLikedSongsResponse, cast(object, raw_songs))
+            tracks = songs.get("tracks")
+            if isinstance(tracks, list):
+                return tracks
+            return []
+        return self.execute(_fetch)
 
     def get_user_saved_albums(self, limit: int = 25) -> list[YTLibraryAlbum]:
-        raw_albums: object = self.client.get_library_albums(limit=limit)
-        return cast(list[YTLibraryAlbum], raw_albums)
+        return self.execute(lambda c: cast(list[YTLibraryAlbum], c.get_library_albums(limit=limit)))
 
     def get_user_playlists(self, limit: int = 25) -> list[YTLibraryPlaylist]:
-        raw_playlists: object = self.client.get_library_playlists(limit=limit)
-        return cast(list[YTLibraryPlaylist], raw_playlists)
+        return self.execute(lambda c: cast(list[YTLibraryPlaylist], c.get_library_playlists(limit=limit)))
 
     def get_track(self, video_id: str) -> YTSongResponse:
-        raw_song: object = self.client.get_song(videoId=video_id)
-        song_dict = cast(dict[str, object], raw_song)
-        video_details = song_dict.get("videoDetails")
-        if not isinstance(video_details, dict):
-            return cast(YTSongResponse, cast(object, {}))
-        track: YTSongResponse = cast(YTSongResponse, cast(object, video_details))
-        track_video_id = track.get('videoId')
-        if isinstance(track_video_id, str):
+        def _fetch(c: YTMusic) -> YTSongResponse:
+            raw_song: object = c.get_song(videoId=video_id)
+            song_dict = cast(dict[str, object], raw_song)
+            video_details = song_dict.get("videoDetails")
+            if not isinstance(video_details, dict):
+                return cast(YTSongResponse, cast(object, {}))
+            track: YTSongResponse = cast(YTSongResponse, cast(object, video_details))
+            track_video_id = track.get("videoId")
+            if isinstance(track_video_id, str):
                 stream_url_and_duration = self.get_stream_url_and_duration(video_id=track_video_id)
-                track['url'] = stream_url_and_duration.get('url')
-                if stream_url_and_duration.get('duration') != None:
-                    track['lengthSeconds'] = str(stream_url_and_duration.get('duration'))
-        
-        return track
+                track["url"] = stream_url_and_duration.get("url")
+                if stream_url_and_duration.get("duration") is not None:
+                    track["lengthSeconds"] = str(stream_url_and_duration.get("duration"))
+            return track
+        return self.execute(_fetch)
 
     def get_album_tracks(self, browse_id: str) -> YTAlbumResponse:
-        raw_album: object = self.client.get_album(browseId=browse_id)
-        return cast(YTAlbumResponse, cast(object, raw_album))
+        return self.execute(lambda c: cast(YTAlbumResponse, cast(object, c.get_album(browseId=browse_id))))
 
     def get_playlist_items(self, playlist_id: str, limit: int = 100) -> YTLikedSongsResponse:
-        raw_playlist: object = self.client.get_playlist(playlistId=playlist_id, limit=limit)
-        return cast(YTLikedSongsResponse, cast(object, raw_playlist))
+        return self.execute(lambda c: cast(YTLikedSongsResponse, cast(object, c.get_playlist(playlistId=playlist_id, limit=limit))))
 
     def get_search_results(self, query: str, filter_type: YTSearchFilter | None = None, limit: int = 20) -> list[YTSearchResult]:
-        raw_results: object = self.client.search(query=query, filter=filter_type, limit=limit)
-        return cast(list[YTSearchResult], raw_results)
+        return self.execute(lambda c: cast(list[YTSearchResult], c.search(query=query, filter=filter_type, limit=limit)))
 
     def get_artist_top_tracks(self, channel_id: str) -> YTArtistResponse:
-        raw_artist: object = self.client.get_artist(channelId=channel_id)
-        return cast(YTArtistResponse, cast(object, raw_artist))
+        return self.execute(lambda c: cast(YTArtistResponse, cast(object, c.get_artist(channelId=channel_id))))
 
     def get_followed_artists(self, limit: int = 25) -> list[YTLibraryArtist]:
-        raw_artists: object = self.client.get_library_subscriptions(limit=limit)
-        return cast(list[YTLibraryArtist], raw_artists)
+        return self.execute(lambda c: cast(list[YTLibraryArtist], c.get_library_subscriptions(limit=limit)))
 
     def get_user_profile(self) -> YTAccountInfo:
-            raw_info: object = self.client.get_account_info()
-            return cast(YTAccountInfo, cast(object, raw_info))
+        return self.execute(lambda c: cast(YTAccountInfo, cast(object, c.get_account_info())))
 
     def get_user_top_items(self) -> list[YTSong]:
-        raw_history: object = self.client.get_history()
-        return cast(list[YTSong], raw_history)
+        return self.execute(lambda c: cast(list[YTSong], c.get_history()))
 
     def check_user_saved_track(self, video_id: str) -> bool:
+        def _check(c: YTMusic) -> bool:
+            raw_song = cast(dict[str, object], c.get_song(videoId=video_id))
+            return True if raw_song else False
         try:
-            raw_song = cast(dict[str, object], self.client.get_song(videoId=video_id))
-            if raw_song:
-                return True
+            return self.execute(_check)
         except Exception:
-            pass
-        return False
+            return False
 
     def save_remove_track(self, video_ids: list[str], is_remove: bool) -> None:
         rating = LikeStatus.INDIFFERENT if is_remove else LikeStatus.LIKE
         for video_id in video_ids:
-            _ = self.client.rate_song(videoId=video_id, rating=rating)
+            self.execute(lambda c: c.rate_song(videoId=video_id, rating=rating))
 
     def search(self, query: str) -> list[YTSong]:
-        res = self.client.search(
-            query,
-            filter="songs"
-        )
-        return cast(list[YTSong], res)
+        return self.execute(lambda c: cast(list[YTSong], c.search(query, filter="songs")))
 
     def like_song(self, video_id: str) -> object:
-        return self.client.rate_song(
-            video_id,
-            LikeStatus.LIKE
-        )
+        return self.execute(lambda c: c.rate_song(video_id, LikeStatus.LIKE))
 
     def unlike_song(self, video_id: str) -> object:
-        return self.client.rate_song(
-            video_id,
-            LikeStatus.INDIFFERENT
-        )
+        return self.execute(lambda c: c.rate_song(video_id, LikeStatus.INDIFFERENT))
 
     def get_song_related(self, browse_id: str) -> list[dict[str, Any]]:
-        raw_related: object = self.client.get_song_related(browseId=browse_id)
-        return cast(list[dict[str, Any]], cast(object, raw_related))
+        if not browse_id or not browse_id.startswith("MPTRt_"):
+            return []
+        try:
+            return self.execute(lambda c: cast(list[dict[str, Any]], cast(object, c.get_song_related(browseId=browse_id))))
+        except Exception as e:
+            print(f"Error in get_song_related: {e}")
+            return []
 
-    def get_lyrics(self, browse_id: str, timestamps: bool = False) -> Lyrics | TimedLyrics | None:
+    def get_lyrics(self, browse_id: str, timestamps: bool = False) -> Lyrics | TimedLyrics | dict[str, Any] | None:
         if timestamps:
+            result = self._get_timed_lyrics_raw(browse_id)
+            if result is not None:
+                return result
             try:
-                return self.client.get_lyrics(browseId=browse_id, timestamps=True)
-            except (KeyError, Exception):
-                result = self._get_timed_lyrics_raw(browse_id)
-                if result is not None:
-                    return result
+                res = self.execute(lambda c: c.get_lyrics(browseId=browse_id, timestamps=True))
+                if res and (isinstance(res, dict) and (res.get("hasTimestamps") or res.get("lyrics"))):
+                    return cast(dict[str, Any], res)
+            except Exception:
+                pass
 
         try:
-            return self.client.get_lyrics(browseId=browse_id, timestamps=False)
+            return self.execute(lambda c: c.get_lyrics(browseId=browse_id, timestamps=False))
         except Exception:
             return None
 
     def _get_timed_lyrics_raw(self, browse_id: str) -> TimedLyrics | None:
         """Parse timed lyrics directly from the mobile API response."""
-        try:
+        def _fetch_mobile(c: YTMusic) -> TimedLyrics | None:
             from ytmusicapi.mixins.browsing import TIMESTAMPED_LYRICS
             from ytmusicapi.navigation import nav
             from ytmusicapi.models.lyrics import LyricLine
 
-            with self.client.as_mobile():
-                response = self.client._send_request("browse", {"browseId": browse_id})
+            with c.as_mobile():
+                response = c._send_request("browse", {"browseId": browse_id})
 
             data = nav(response, TIMESTAMPED_LYRICS, True)
             if not isinstance(data, dict) or "timedLyricsData" not in data:
@@ -209,11 +231,19 @@ class MusicClient:
                 source=data.get("sourceMessage"),
                 hasTimestamps=True,
             )
+        try:
+            return self.execute(_fetch_mobile)
         except Exception:
             return None
 
     def get_watch_playlist(self, video_id: str) -> dict[str, Any]:
-        raw_watch: object = self.client.get_watch_playlist(videoId=video_id)
-        if isinstance(raw_watch, dict):
-            return cast(dict[str, Any], raw_watch)
-        return {}
+        if not video_id:
+            return {}
+        try:
+            res = self.execute(lambda c: c.get_watch_playlist(videoId=video_id))
+            if isinstance(res, dict):
+                return cast(dict[str, Any], res)
+            return {}
+        except Exception as e:
+            print(f"Error in get_watch_playlist: {e}")
+            return {}

--- a/proto/music.proto
+++ b/proto/music.proto
@@ -372,6 +372,7 @@ message GetVideoStreamURLAndDurationResponse {
 
 message GetSongRelatedRequest {
   string videoId = 1;
+  string browse_id = 2;
 }
 
 message GetSongRelatedResponse {


### PR DESCRIPTION
failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when song-related requests lack valid identifiers.
  * Prevented request failures from surfacing as internal server errors.
  * Added safer fallback behavior for authentication, lyrics, and other music data requests.
  * Added automatic retrying for failed music service operations.

* **Reliability**
  * Improved client startup and recovery by reusing connections and resetting them when needed.
  * Added validation for invalid request inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->