### PR TITLE
fix: pass youtube cookies to ffmpeg to bypass 403 issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ wheels/
 browser.json
 gen/
 backend/binaries/python-*
+.vercel
+.env*

--- a/internal/cookie/cookie.go
+++ b/internal/cookie/cookie.go
@@ -18,9 +18,12 @@ import (
 var (
 	cachedCookieHeader string
 	cookieHeaderOnce   sync.Once
+	cookieHeaderMu     sync.RWMutex
 )
 
 func ResetCookieHeaderCache() {
+	cookieHeaderMu.Lock()
+	defer cookieHeaderMu.Unlock()
 	cachedCookieHeader = ""
 	cookieHeaderOnce = sync.Once{}
 }
@@ -205,6 +208,16 @@ func EnsureCookieFile() string {
 }
 
 func GetCookieHeader() string {
+	cookieHeaderMu.RLock()
+	header := cachedCookieHeader
+	cookieHeaderMu.RUnlock()
+	if header != "" {
+		return header
+	}
+
+	cookieHeaderMu.Lock()
+	defer cookieHeaderMu.Unlock()
+
 	cookieHeaderOnce.Do(func() {
 		configDir := config.GetConfigDir(runtime.GOOS)
 		browserPath := filepath.Join(configDir, "browser.json")

--- a/internal/cookie/cookie.go
+++ b/internal/cookie/cookie.go
@@ -10,9 +10,20 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/kumneger0/ytmusic-tui/internal/config"
 )
+
+var (
+	cachedCookieHeader string
+	cookieHeaderOnce   sync.Once
+)
+
+func ResetCookieHeaderCache() {
+	cachedCookieHeader = ""
+	cookieHeaderOnce = sync.Once{}
+}
 
 func ConvertToNetscapeCookies(cookieText string) string {
 	cookieText = strings.TrimSpace(cookieText)
@@ -157,6 +168,7 @@ func GetCookieFilePath() string {
 }
 
 func SaveCookieFile(cookieText string) (string, error) {
+	ResetCookieHeaderCache()
 	cookiePath := GetCookieFilePath()
 	netscapeContent := ConvertToNetscapeCookies(cookieText)
 
@@ -190,4 +202,35 @@ func EnsureCookieFile() string {
 		return ""
 	}
 	return path
+}
+
+func GetCookieHeader() string {
+	cookieHeaderOnce.Do(func() {
+		configDir := config.GetConfigDir(runtime.GOOS)
+		browserPath := filepath.Join(configDir, "browser.json")
+		if browserData, err := os.ReadFile(browserPath); err == nil && len(browserData) > 0 {
+			var rawData map[string]interface{}
+			if err := json.Unmarshal(browserData, &rawData); err == nil {
+				if c, ok := rawData["Cookie"].(string); ok && c != "" {
+					cachedCookieHeader = c
+					return
+				}
+				if c, ok := rawData["cookie"].(string); ok && c != "" {
+					cachedCookieHeader = c
+					return
+				}
+				if headersObj, ok := rawData["headers"].(map[string]interface{}); ok {
+					if c, ok := headersObj["Cookie"].(string); ok && c != "" {
+						cachedCookieHeader = c
+						return
+					}
+					if c, ok := headersObj["cookie"].(string); ok && c != "" {
+						cachedCookieHeader = c
+						return
+					}
+				}
+			}
+		}
+	})
+	return cachedCookieHeader
 }

--- a/internal/cookie/cookie_test.go
+++ b/internal/cookie/cookie_test.go
@@ -68,6 +68,7 @@ func TestEnsureCookieFile(t *testing.T) {
 
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 	t.Setenv("HOME", tmpDir)
+	ResetCookieHeaderCache()
 
 	configDir := config.GetConfigDir(runtime.GOOS)
 	browserPath := filepath.Join(configDir, "browser.json")
@@ -89,5 +90,10 @@ func TestEnsureCookieFile(t *testing.T) {
 	}
 	if !strings.Contains(string(content), "TEST\t123") {
 		t.Fatalf("unexpected cookie file content: %s", string(content))
+	}
+
+	header := GetCookieHeader()
+	if header != "TEST=123" {
+		t.Fatalf("expected 'TEST=123', got %q", header)
 	}
 }

--- a/internal/ui/renderers.go
+++ b/internal/ui/renderers.go
@@ -47,15 +47,8 @@ func (d CustomDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 				isSelected = m.Index() == index
 			}
 		case QueueList:
-			showRelated := (d.Model.RightColumnMode == RightColumnRelated || d.Model.RightColumnMode == "") && len(d.Model.RelatedList.Items()) > 0
-			if showRelated {
-				if m.Title == "Related" {
-					isSelected = m.Index() == index
-				}
-			} else {
-				if m.Title == "Queue" {
-					isSelected = m.Index() == index
-				}
+			if m.Title == "Related" || m.Title == "Queue" {
+				isSelected = m.Index() == index
 			}
 		}
 	}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -254,8 +254,6 @@ type LayoutDimensions struct {
 	InputHeight   int
 }
 
-type layoutDimensions = LayoutDimensions
-
 func CalculateLayoutDimensions(m *Model) LayoutDimensions {
 	if m.Width <= 0 || m.Height <= 0 {
 		m.Width = 100

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1639,6 +1639,7 @@ func (m Model) handleSearchBarEnter() (Model, tea.Cmd) {
 	query := m.Search.Value()
 	if query == m.SearchQuery && len(m.SearchResult.Items()) > 0 {
 		m.MainViewMode = SearchResultMode
+		m.FocusedOn = MainView
 		return m, nil
 	}
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1638,9 +1638,13 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 func (m Model) handleSearchBarEnter() (Model, tea.Cmd) {
 	query := m.Search.Value()
 	if query == m.SearchQuery && len(m.SearchResult.Items()) > 0 {
-		m.MainViewMode = SearchResultMode
-		m.FocusedOn = MainView
-		return m, nil
+		if query == m.SearchQuery && len(m.SearchResult.Items()) > 0 {
+			m.MainViewMode = SearchResultMode
+			m.Search.Blur()
+			m.FocusedOn = MainView
+			updateDelegate(&m)
+			return m, nil
+		}
 	}
 
 	loadingCmd := SendLoadingCmd()

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -91,19 +92,32 @@ func SearchAndDownloadMusic(
 			}
 		}
 
-		ff, err := command.ExecCommand(ctx,
-			coreDepsPath.FFmpeg,
+		var headersBuf strings.Builder
+		if streamURL.HTTPHeaders != nil {
+			for k, v := range streamURL.HTTPHeaders {
+				fmt.Fprintf(&headersBuf, "%s: %s\r\n", k, v)
+			}
+		}
+
+		ffArgs := []string{
 			"-reconnect", "1",
 			"-reconnect_streamed", "1",
 			"-reconnect_delay_max", "5",
 			"-reconnect_on_network_error", "1",
 			"-reconnect_on_http_error", "1",
+		}
+		if h := headersBuf.String(); h != "" {
+			ffArgs = append(ffArgs, "-headers", h)
+		}
+		ffArgs = append(ffArgs,
 			"-i", streamURL.URL,
 			"-f", "s16le",
 			"-ac", "2",
 			"-ar", "44100",
 			"pipe:1",
 		)
+
+		ff, err := command.ExecCommand(ctx, coreDepsPath.FFmpeg, ffArgs...)
 
 		if err != nil {
 			_ = ffStderr.Close()
@@ -226,8 +240,9 @@ func SearchAndDownloadMusic(
 }
 
 type StreamAndDuration struct {
-	URL      string
-	Duration string
+	URL         string
+	Duration    string
+	HTTPHeaders map[string]string
 }
 
 func logYtDlpErr(err error) {
@@ -281,8 +296,9 @@ func GetStreamURLAndDuration(ctx context.Context, videoID string, ytdlpPath stri
 	}
 
 	var data struct {
-		URL      string  `json:"url"`
-		Duration float64 `json:"duration"`
+		URL         string            `json:"url"`
+		Duration    float64           `json:"duration"`
+		HTTPHeaders map[string]string `json:"http_headers"`
 	}
 	if err := json.Unmarshal(outBytes, &data); err != nil {
 		logYtDlpErr(err)
@@ -295,9 +311,21 @@ func GetStreamURLAndDuration(ctx context.Context, videoID string, ytdlpPath stri
 		return nil, err
 	}
 
+	if data.HTTPHeaders == nil {
+		data.HTTPHeaders = make(map[string]string)
+	}
+	if _, ok := data.HTTPHeaders["Cookie"]; !ok {
+		if _, okLower := data.HTTPHeaders["cookie"]; !okLower {
+			if cookieStr := cookie.GetCookieHeader(); cookieStr != "" {
+				data.HTTPHeaders["Cookie"] = cookieStr
+			}
+		}
+	}
+
 	durationInSeconds := int64(data.Duration)
 	return &StreamAndDuration{
-		URL:      data.URL,
-		Duration: strconv.FormatInt(durationInSeconds, 10),
+		URL:         data.URL,
+		Duration:    strconv.FormatInt(durationInSeconds, 10),
+		HTTPHeaders: data.HTTPHeaders,
 	}, nil
 }

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -314,12 +314,20 @@ func GetStreamURLAndDuration(ctx context.Context, videoID string, ytdlpPath stri
 	if data.HTTPHeaders == nil {
 		data.HTTPHeaders = make(map[string]string)
 	}
-	if _, ok := data.HTTPHeaders["Cookie"]; !ok {
-		if _, okLower := data.HTTPHeaders["cookie"]; !okLower {
-			if cookieStr := cookie.GetCookieHeader(); cookieStr != "" {
-				data.HTTPHeaders["Cookie"] = cookieStr
+	cookieHeader := ""
+	for key, value := range data.HTTPHeaders {
+		if strings.EqualFold(key, "Cookie") {
+			delete(data.HTTPHeaders, key)
+			if cookieHeader == "" && strings.TrimSpace(value) != "" {
+				cookieHeader = value
 			}
 		}
+	}
+	if cookieHeader == "" {
+		cookieHeader = cookie.GetCookieHeader()
+	}
+	if cookieHeader != "" {
+		data.HTTPHeaders["Cookie"] = cookieHeader
 	}
 
 	durationInSeconds := int64(data.Duration)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback reliability for streams requiring cookie-based authentication.
  * Preserved required HTTP headers when launching video streams.
  * Queue and related items now display selection consistently.
  * Reusing an existing search with results now returns focus to the main view.
* **Improvements**
  * Cookie updates are recognized immediately without requiring an application restart.
* **Maintenance**
  * Updated ignored configuration and environment files to help prevent accidental inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->