### PR TITLE
chore: bump ytmusicapi to 1.12.2

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -296,9 +296,8 @@ func (m *Model) SetPlaybackContext(tracks []*types.PlaylistTrackObject, name str
 	m.PlaylistContextIndex = currentIndex
 }
 
-func (m *Model) SyncQueueList() {
+func (m *Model) SyncQueueList() tea.Cmd {
 	var items []list.Item
-
 	if m.Queue != nil && m.Queue.Len() > 0 {
 		userQueueTracks := m.Queue.AllTracks()
 		items = append(items, types.HomePageSectionItem{SectionTitle: "Queue"})
@@ -339,8 +338,7 @@ func (m *Model) SyncQueueList() {
 			}
 		}
 	}
-
-	m.QueueList.SetItems(items)
+	return m.QueueList.SetItems(items)
 }
 
 func RemoveListDefaults(listToRemoveDefaults *list.Model) {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1031,8 +1031,9 @@ func (m Model) handleMusicChange(isForward bool) (Model, tea.Cmd) {
 			fromHistory = true
 		}
 
-		if track != nil && !fromHistory && m.PlayedSeconds > 30000 {
-			appendToPlayHistory(&m, track)
+		if !fromHistory && m.PlayedSeconds > 30 &&
+			m.SelectedTrack != nil && m.SelectedTrack.Track != nil {
+			appendToPlayHistory(&m, m.SelectedTrack.Track)
 		}
 	} else {
 		if len(m.PlayHistory) > 0 && m.PlayHistoryIndex > 0 {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -754,6 +754,7 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case "a":
 		return m.addMusicToQueue()
 	case "r":
+		var cmd tea.Cmd
 		showRelated := (m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "") && len(m.RelatedList.Items()) > 0
 		if m.FocusedOn == QueueList && !showRelated {
 			shouldIRemoveFromPlaybackContext := true
@@ -765,7 +766,7 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 					shouldIRemoveFromPlaybackContext = false
 					m.Queue.RemoveTrackAtIndex(trackIdx)
 				}
-				m.SyncQueueList()
+				cmd = m.SyncQueueList()
 			}
 
 			if shouldIRemoveFromPlaybackContext {
@@ -780,15 +781,16 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 						}
 					}
 				}
-				if itemIndex != -1 {
+				if itemIndex != -1 && itemIndex < len(m.PlaybackContext) {
 					itemsToKeep := m.PlaybackContext[:itemIndex]
 					if itemIndex+1 < len(m.PlaybackContext) {
 						itemsToKeep = append(itemsToKeep, m.PlaybackContext[itemIndex+1:]...)
 					}
 					m.PlaybackContext = itemsToKeep
-					m.SyncQueueList()
+					cmd = m.SyncQueueList()
 				}
 			}
+			return m, cmd
 		}
 	case "ctrl+l":
 		if m.MainViewMode == LyricsMode {
@@ -1028,7 +1030,7 @@ func (m Model) handleMusicChange(isForward bool) (Model, tea.Cmd) {
 			fromHistory = true
 		}
 
-		if track != nil && !fromHistory {
+		if track != nil && !fromHistory && m.PlayedSeconds > 30000 {
 			appendToPlayHistory(&m, track)
 		}
 	} else {
@@ -1121,7 +1123,8 @@ func (m Model) addMusicToQueue() (Model, tea.Cmd) {
 			}
 		}
 	case QueueList:
-		if len(m.RelatedList.Items()) > 0 {
+		showRelated := (m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "") && len(m.RelatedList.Items()) > 0
+		if len(m.RelatedList.Items()) > 0 && showRelated {
 			selectedItem = m.RelatedList.SelectedItem()
 		}
 	}
@@ -1132,17 +1135,8 @@ func (m Model) addMusicToQueue() (Model, tea.Cmd) {
 	}
 
 	m.Queue.AddTrack(track)
-	m.SyncQueueList()
-
 	toastCmd := m.Alert.NewAlertCmd(bubbleup.InfoKey, fmt.Sprintf("Added \"%s\" to queue", track.Title()))
-
-	if m.SelectedTrack == nil {
-		model, playCmd := m.handleMusicChange(true)
-		m = model
-		return m, tea.Batch(playCmd, toastCmd)
-	}
-
-	return m, toastCmd
+	return m, tea.Batch(toastCmd, m.SyncQueueList())
 }
 
 func (m Model) HandleMusicPausePlay() (Model, tea.Cmd) {
@@ -1296,7 +1290,6 @@ func (m Model) playStandaloneTrack(track types.PlaylistTrackObject) (Model, tea.
 	m.PlaybackContextName = ""
 	m.PlaylistContextIndex = 0
 
-	appendToPlayHistory(&m, &track)
 	return m.PlaySelectedMusic(track)
 }
 
@@ -1321,7 +1314,6 @@ func (m Model) playTrackFromList(track types.PlaylistTrackObject) (Model, tea.Cm
 	selectedIdx := m.SelectedPlayListItems.Index()
 	m.SetPlaybackContext(contextTracks, contextName, selectedIdx)
 
-	appendToPlayHistory(&m, &track)
 	return m.PlaySelectedMusic(track)
 }
 
@@ -1379,7 +1371,6 @@ func (m Model) handleHomePageEnter() (Model, tea.Cmd) {
 				m.SetPlaybackContext(contextTracks, contextName, selectedIdx)
 			}
 
-			appendToPlayHistory(&m, &playlistTrack)
 			return m.PlaySelectedMusic(playlistTrack)
 		} else if item.ContentType == "album" || strings.HasPrefix(item.BrowseID, "MPRE") {
 			browseID := item.BrowseID
@@ -1447,6 +1438,7 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 			}
 		}
 
+		var queueListUpdateCmd tea.Cmd
 		if m.FocusedOn == QueueList {
 			selectedIdx := m.QueueList.Index()
 			inQueue := false
@@ -1458,7 +1450,7 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 					for i := 0; i <= trackIdx; i++ {
 						m.Queue.PopFirst()
 					}
-					m.SyncQueueList()
+					queueListUpdateCmd = m.SyncQueueList()
 					if len(m.QueueList.Items()) > 0 {
 						m.QueueList.Select(0)
 					}
@@ -1469,7 +1461,7 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 				for idx, ctxTrack := range m.PlaybackContext {
 					if ctxTrack != nil && ctxTrack.Track != nil && selectedItem.Track != nil && ctxTrack.Track.VideoId == selectedItem.Track.VideoId {
 						m.PlaylistContextIndex = idx
-						m.SyncQueueList()
+						queueListUpdateCmd = m.SyncQueueList()
 						if len(m.QueueList.Items()) > 0 {
 							m.QueueList.Select(0)
 						}
@@ -1478,13 +1470,12 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 				}
 			}
 
-			appendToPlayHistory(&m, &selectedItem)
 			m, cmd := m.PlaySelectedMusic(selectedItem)
-			return m, tea.Batch(cmd, relatedSongsCmd)
+			return m, tea.Batch(cmd, relatedSongsCmd, queueListUpdateCmd)
 		}
 
 		m, cmd := m.playTrackFromList(selectedItem)
-		return m, tea.Batch(cmd, relatedSongsCmd)
+		return m, tea.Batch(cmd, relatedSongsCmd, queueListUpdateCmd)
 
 	case types.SongItem:
 		playlistTrack := types.PlaylistTrackObject{Track: selectedItem.Song}
@@ -1876,7 +1867,7 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 		Track:   &selectedMusic,
 	}
 
-	m.SyncQueueList()
+	cmds = append(cmds, m.SyncQueueList())
 	return m, tea.Batch(cmds...)
 }
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -754,22 +754,40 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 	case "a":
 		return m.addMusicToQueue()
 	case "r":
-		if m.FocusedOn == QueueList {
-			showRelated := (m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "") && len(m.RelatedList.Items()) > 0
-			if showRelated {
-				if len(m.RelatedList.Items()) > 0 {
-					m.RelatedList.RemoveItem(m.RelatedList.Index())
-				}
-			} else if m.Queue != nil && m.Queue.Len() > 0 {
+		showRelated := (m.RightColumnMode == RightColumnRelated || m.RightColumnMode == "") && len(m.RelatedList.Items()) > 0
+		if m.FocusedOn == QueueList && !showRelated {
+			shouldIRemoveFromPlaybackContext := true
+			if m.Queue != nil && m.Queue.Len() > 0 {
 				selectedIdx := m.QueueList.Index()
 				userQueueTracks := m.Queue.AllTracks()
 				trackIdx := selectedIdx - 1
 				if trackIdx >= 0 && trackIdx < len(userQueueTracks) {
+					shouldIRemoveFromPlaybackContext = false
 					m.Queue.RemoveTrackAtIndex(trackIdx)
-				} else {
-					m.Queue.RemoveCurrent()
 				}
 				m.SyncQueueList()
+			}
+
+			if shouldIRemoveFromPlaybackContext {
+				itemIndex := -1
+				if selectedTrack, ok := m.QueueList.SelectedItem().(types.PlaylistTrackObject); ok {
+					for i, track := range m.QueueList.Items() {
+						if t, ok := track.(types.PlaylistTrackObject); ok {
+							if t.Track.VideoId == selectedTrack.Track.VideoId {
+								itemIndex = i
+								break
+							}
+						}
+					}
+				}
+				if itemIndex != -1 {
+					itemsToKeep := m.PlaybackContext[:itemIndex]
+					if itemIndex+1 < len(m.PlaybackContext) {
+						itemsToKeep = append(itemsToKeep, m.PlaybackContext[itemIndex+1:]...)
+					}
+					m.PlaybackContext = itemsToKeep
+					m.SyncQueueList()
+				}
 			}
 		}
 	case "ctrl+l":

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -772,9 +772,10 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 			if shouldIRemoveFromPlaybackContext {
 				itemIndex := -1
 				if selectedTrack, ok := m.QueueList.SelectedItem().(types.PlaylistTrackObject); ok {
-					for i, track := range m.QueueList.Items() {
-						if t, ok := track.(types.PlaylistTrackObject); ok {
-							if t.Track.VideoId == selectedTrack.Track.VideoId {
+					if selectedTrack.Track != nil {
+						for i, track := range m.PlaybackContext {
+							if track != nil && track.Track != nil &&
+								track.Track.VideoId == selectedTrack.Track.VideoId {
 								itemIndex = i
 								break
 							}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -329,6 +329,8 @@ func TestUpdate_QueueList_RemovalAndNavigation(t *testing.T) {
 	trackObj := types.PlaylistTrackObject{Track: &musicpb.Song{VideoId: "song1", Title: "Song 1"}}
 	m.Queue = queue.NewRingQueue()
 	m.Queue.AddTrack(&trackObj)
+	m.SyncQueueList()
+	m.QueueList.Select(1)
 
 	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
 	updated := result.(Model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "protoc-gen-connect-python>=0.9.0",
     "python-dotenv>=1.2.2",
     "uvicorn>=0.34.0",
-    "ytmusicapi>=1.12.1",
+    "ytmusicapi>=1.12.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -545,7 +545,7 @@ requires-dist = [
     { name = "protoc-gen-connect-python", specifier = ">=0.9.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "uvicorn", specifier = ">=0.34.0" },
-    { name = "ytmusicapi", specifier = ">=1.12.1" },
+    { name = "ytmusicapi", specifier = ">=1.12.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -553,12 +553,12 @@ dev = [{ name = "basedpyright", specifier = ">=1.39.9" }]
 
 [[package]]
 name = "ytmusicapi"
-version = "1.12.1"
+version = "1.12.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/16/f9737ae3a565abaf2e3d106507272f85e43abff6886fb514a22db3a8adaf/ytmusicapi-1.12.1.tar.gz", hash = "sha256:4e33f424db311ece1b9e5f29a51ade46b0697f6e2f284f8a40bcbd7219772755", size = 529510, upload-time = "2026-06-05T16:36:18.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/56/3813d8fb327f5d91777dfb715d73030324920f030ffdc10fd05fd1f79761/ytmusicapi-1.12.2.tar.gz", hash = "sha256:8674ab9a02d2c1bdf137166c78dcf4c4568360e46ede1b31549edf6750db530a", size = 663466, upload-time = "2026-08-08T18:30:29.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/6d/f7156e7ab9953d09e14ef538de4e92c484169fac19d207b19b9d9eb9c845/ytmusicapi-1.12.1-py3-none-any.whl", hash = "sha256:2a53f6df504b97b93a4d41c804b699b46190207cb9d864fcf4edeb338b1f15d9", size = 108567, upload-time = "2026-06-05T16:36:16.523Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b8/5a925aabd5fa7c31f20bf84d352a3fc372aa62cc0965f27dd43f8a22289f/ytmusicapi-1.12.2-py3-none-any.whl", hash = "sha256:54b42b26d76de9b954f306a44e1ba4413a830cb2c41c019d255a297af941711e", size = 110857, upload-time = "2026-08-08T18:30:28.529Z" },
 ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved track removal so it applies correctly to the active queue and does not remove related-song items.
  - Kept queue contents synchronized after adding or removing tracks.
  - Prevented unintended playback from starting when adding a track without a selection.
  - Improved playback history accuracy by recording tracks only after sufficient listening time.
  - Improved queue navigation and selection behavior across supported views.
- **Chores**
  - Updated the YouTube Music integration dependency for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->