### PR TITLE
feat: use lrclib for lyrics as fallback

### DIFF
--- a/internal/ui/renderers.go
+++ b/internal/ui/renderers.go
@@ -182,7 +182,8 @@ func (d CustomDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 		icon = "♫"
 		if item.Track != nil {
 			title = item.Track.Title
-			if d.Model != nil && d.Model.SelectedTrack != nil && item.Track.VideoId == d.Model.SelectedTrack.Track.VideoId {
+			if d.Model != nil && d.Model.SelectedTrack != nil && d.Model.SelectedTrack.Track != nil &&
+				item.Track.VideoId == d.Model.SelectedTrack.Track.VideoId {
 				title += " (current)"
 			}
 			if len(item.Track.Artists) > 0 {
@@ -307,7 +308,7 @@ func renderSearchBar(m *Model, width int) string {
 
 func renderNowPlaying(m *Model, currentPosition, TotalDuration time.Duration) string {
 	selectedTrack := m.SelectedTrack
-	if selectedTrack == nil {
+	if selectedTrack == nil || selectedTrack.Track == nil {
 		return ""
 	}
 	var artistNames []string

--- a/internal/ui/renderers.go
+++ b/internal/ui/renderers.go
@@ -182,7 +182,7 @@ func (d CustomDelegate) Render(w io.Writer, m list.Model, index int, item list.I
 		icon = "♫"
 		if item.Track != nil {
 			title = item.Track.Title
-			if d.Model != nil && d.Model.SelectedTrack != nil && d.Model.SelectedTrack.Track != nil && d.Model.SelectedTrack.Track.Track != nil && item.Track.VideoId == d.Model.SelectedTrack.Track.Track.VideoId {
+			if d.Model != nil && d.Model.SelectedTrack != nil && item.Track.VideoId == d.Model.SelectedTrack.Track.VideoId {
 				title += " (current)"
 			}
 			if len(item.Track.Artists) > 0 {
@@ -311,12 +311,12 @@ func renderNowPlaying(m *Model, currentPosition, TotalDuration time.Duration) st
 		return ""
 	}
 	var artistNames []string
-	var artists = selectedTrack.Track.Track.Artists
+	var artists = selectedTrack.Track.Artists
 	for _, artist := range artists {
 		artistNames = append(artistNames, artist.Name)
 	}
 	artistName := strings.Join(artistNames, ", ")
-	trackName := selectedTrack.Track.Track.Title
+	trackName := selectedTrack.Track.Title
 
 	var likedIndicator string
 	if selectedTrack.isLiked {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -67,8 +67,8 @@ type SpotifySearchResult struct {
 }
 
 type SelectedTrack struct {
+	types.PlaylistTrackObject
 	isLiked bool
-	Track   *types.PlaylistTrackObject
 }
 
 type MusicQueueList struct {
@@ -193,8 +193,8 @@ func (m Model) View() string {
 		)
 	} else if m.MainViewMode == LyricsMode {
 		trackName := ""
-		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && m.SelectedTrack.Track.Track != nil {
-			trackName = " • " + m.SelectedTrack.Track.Track.Title
+		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil {
+			trackName = " • " + m.SelectedTrack.Track.Title
 		}
 		lyricsHeader := titleStyle.Render("  📝 Lyrics" + trackName)
 		lyricsPadded := lipgloss.NewStyle().Padding(1, 2).Render(m.LyricsView.View())
@@ -212,10 +212,10 @@ func (m Model) View() string {
 
 	var playingView string
 
-	if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && m.SelectedTrack.Track.Track != nil {
+	if m.SelectedTrack != nil && m.SelectedTrack.Track != nil {
 		playedSeconds := int(m.PlayedSeconds)
 		currentPosition := time.Second * time.Duration(playedSeconds)
-		total := time.Duration(m.SelectedTrack.Track.Track.DurationSeconds) * time.Second
+		total := time.Duration(m.SelectedTrack.Track.DurationSeconds) * time.Second
 		playingView = renderNowPlaying(&m, currentPosition, total)
 	}
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/charmbracelet/bubbles/list"
@@ -372,7 +373,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Player == nil {
 			return m, nil
 		}
-		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && msg.VideoID != m.SelectedTrack.Track.VideoId {
+		if m.SelectedTrack == nil || m.SelectedTrack.Track == nil {
+			_ = msg.Player.Close()
+			return m, nil
+		}
+		if msg.VideoID != m.SelectedTrack.Track.VideoId {
 			_ = msg.Player.Close()
 			return m, nil
 		}
@@ -932,6 +937,15 @@ func getNextPageItems(m *Model, paginationInfo *types.PaginationInfo) tea.Cmd {
 	}
 	return nil
 }
+
+type lrclibQuery struct {
+	videoID     string
+	trackName   string
+	albumName   string
+	artistName  string
+	durationSec int32
+}
+
 func (m Model) getMusicLyrics() (Model, tea.Cmd) {
 	if m.MainViewMode == LyricsMode {
 		m.MainViewMode = NormalMode
@@ -940,31 +954,46 @@ func (m Model) getMusicLyrics() (Model, tea.Cmd) {
 		m.FocusedOn = MainView
 	}
 
-	if m.SelectedTrack == nil || m.SelectedTrack.Track == nil ||
-		m.SelectedTrack.Track.DurationSeconds == 0 {
+	if m.SelectedTrack == nil || m.SelectedTrack.Track == nil {
 		return m, nil
 	}
 
 	m.LyricsView.SetContent("  ⟳ Loading lyrics...")
-	selectedTrack := m.SelectedTrack
+
+	q := lrclibQuery{
+		videoID:     m.SelectedTrack.Track.VideoId,
+		trackName:   m.SelectedTrack.Track.Title,
+		albumName:   m.SelectedTrack.Track.Album,
+		durationSec: m.SelectedTrack.Track.DurationSeconds,
+	}
+	if len(m.SelectedTrack.Track.Artists) > 0 {
+		q.artistName = m.SelectedTrack.Track.Artists[0].Name
+	}
+
+	ytClient := m.YtMusicClient
+
 	lyricsCmd := func() tea.Msg {
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
 		var backendResp *musicpb.GetLyricsResponse
-		lyricsResponse, err := m.YtMusicClient.GetLyrics(ctx, connect.NewRequest(&musicpb.GetLyricsRequest{
-			VideoId:    selectedTrack.Track.VideoId,
+		lyricsResponse, err := ytClient.GetLyrics(ctx, connect.NewRequest(&musicpb.GetLyricsRequest{
+			VideoId:    q.videoID,
 			Timestamps: true,
 		}))
 		if err == nil && lyricsResponse != nil {
 			backendResp = lyricsResponse.Msg
 		}
 
+		if err != nil {
+			slog.Debug("backend GetLyrics failed", "videoId", q.videoID, "err", err)
+		}
+
 		if backendResp != nil && backendResp.HasTimestamps && len(backendResp.Lines) > 0 {
 			return types.LyricsMsg{LyricsResponse: backendResp}
 		}
 
-		lrclibResp := fetchLrclib(ctx, selectedTrack)
+		lrclibResp := fetchLrclib(ctx, q)
 
 		if lrclibResp != nil && lrclibResp.SyncedLyrics != "" {
 			lines := parseSyncedLyrics(lrclibResp.SyncedLyrics)
@@ -1003,40 +1032,51 @@ type lrclibResponse struct {
 	PlainLyrics  string `json:"plainLyrics"`
 }
 
-func fetchLrclib(ctx context.Context, track *SelectedTrack) *lrclibResponse {
+func fetchLrclib(ctx context.Context, q lrclibQuery) *lrclibResponse {
 	params := url.Values{}
-	params.Add("track_name", track.Track.Title)
-	if track.Track.Album != "" {
-		params.Add("album_name", track.Track.Album)
+	params.Add("track_name", q.trackName)
+	if q.albumName != "" {
+		params.Add("album_name", q.albumName)
 	}
-	if len(track.Track.Artists) > 0 {
-		params.Add("artist_name", track.Track.Artists[0].Name)
+	if q.artistName != "" {
+		params.Add("artist_name", q.artistName)
 	}
-	params.Add("duration", strconv.FormatInt(int64(track.Track.DurationSeconds), 10))
+	if q.durationSec > 0 {
+		params.Add("duration", strconv.FormatInt(int64(q.durationSec), 10))
+	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://lrclib.net/api/get?"+params.Encode(), nil)
+	reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer reqCancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, "GET", "https://lrclib.net/api/get?"+params.Encode(), nil)
 	if err != nil {
+		slog.Debug("lrclib NewRequest error", "err", err)
 		return nil
 	}
 	req.Header.Set("User-Agent", "ytmusic-tui/1.0")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
+		slog.Debug("lrclib request failed", "err", err)
 		return nil
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		slog.Debug("lrclib non-200 status code", "status", resp.StatusCode)
 		return nil
 	}
 
-	data, err := io.ReadAll(resp.Body)
+	limitedReader := io.LimitReader(resp.Body, 512*1024)
+	data, err := io.ReadAll(limitedReader)
 	if err != nil {
+		slog.Debug("lrclib read body error", "err", err)
 		return nil
 	}
 
 	var result lrclibResponse
 	if err := json.Unmarshal(data, &result); err != nil {
+		slog.Debug("lrclib unmarshal error", "err", err)
 		return nil
 	}
 	return &result
@@ -1081,28 +1121,30 @@ func parseLRCTimestamp(ts string) (int32, bool) {
 		return 0, false
 	}
 	secParts := strings.Split(parts[1], ".")
-	if len(secParts) != 2 {
+	if len(secParts) > 2 {
 		return 0, false
 	}
 	seconds, err := strconv.Atoi(secParts[0])
 	if err != nil {
 		return 0, false
 	}
-	frac := secParts[1]
-	fracVal, err := strconv.Atoi(frac)
-	if err != nil {
-		return 0, false
-	}
 	var fracMs int
-	switch len(frac) {
-	case 1:
-		fracMs = fracVal * 100
-	case 2:
-		fracMs = fracVal * 10
-	case 3:
-		fracMs = fracVal
-	default:
-		fracMs = fracVal
+	if len(secParts) == 2 {
+		frac := secParts[1]
+		fracVal, err := strconv.Atoi(frac)
+		if err != nil {
+			return 0, false
+		}
+		switch len(frac) {
+		case 1:
+			fracMs = fracVal * 100
+		case 2:
+			fracMs = fracVal * 10
+		case 3:
+			fracMs = fracVal
+		default:
+			fracMs = fracVal
+		}
 	}
 
 	return int32(minutes*60000 + seconds*1000 + fracMs), true
@@ -1988,6 +2030,7 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 	m.playbackCancel = cancel
 	cmd := youtube.SearchAndDownloadMusic(playCtx, selectedMusic.Track.VideoId, m.CoreDepsPath)
 	m.CurrentLyrics = nil
+	m.LyricsView.SetContent("")
 
 	cmds = append(cmds, cmd)
 	metadata := getMusicMetadata(MusicMetadata{

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -2,9 +2,13 @@ package ui
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -368,13 +372,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Player == nil {
 			return m, nil
 		}
-		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && m.SelectedTrack.Track.Track != nil && msg.VideoID != m.SelectedTrack.Track.Track.VideoId {
+		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && msg.VideoID != m.SelectedTrack.Track.VideoId {
 			_ = msg.Player.Close()
 			return m, nil
 		}
-		if m.SelectedTrack.Track.Track.DurationSeconds == 0 && msg.Duration != "" {
+		if m.SelectedTrack.Track.DurationSeconds == 0 && msg.Duration != "" {
 			if duration, err := strconv.ParseInt(msg.Duration, 10, 64); err == nil {
-				m.SelectedTrack.Track.Track.DurationSeconds = int32(duration)
+				m.SelectedTrack.Track.DurationSeconds = int32(duration)
 			} else {
 				slog.Error(err.Error())
 			}
@@ -456,11 +460,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			alertCmd := m.Alert.NewAlertCmd(bubbleup.ErrorKey, msg.Err.Error())
 			return m, alertCmd
 		}
-		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && m.SelectedTrack.Track.Track != nil && m.SelectedTrack.Track.Track.VideoId == msg.TrackID {
+		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && m.SelectedTrack.Track.VideoId == msg.TrackID {
 			m.SelectedTrack.isLiked = msg.Liked
 		}
 	case types.PlayedSecondsUpdateMsg:
-		if m.SelectedTrack == nil || m.SelectedTrack.Track == nil || m.SelectedTrack.Track.Track == nil {
+		if m.SelectedTrack == nil || m.SelectedTrack.Track == nil {
 			return m, nil
 		}
 		oldSec := int(m.PlayedSeconds)
@@ -472,7 +476,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.CurrentLyrics != nil {
 			m.updateLyricsView()
 		}
-		totalDurationInSeconds := m.SelectedTrack.Track.Track.DurationSeconds
+		totalDurationInSeconds := m.SelectedTrack.Track.DurationSeconds
 		if totalDurationInSeconds > 0 && (float64(totalDurationInSeconds)-m.PlayedSeconds) < 1 {
 			m.PlayedSeconds = 0
 			model, cmd := m.handleMusicChange(true)
@@ -625,7 +629,7 @@ func (m Model) handleDbusMessage(msg types.MessageType) (Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) handlePagination(listModel *list.Model, ShouldAppendQueue bool, currentIndex *int) (Model, tea.Cmd) {
+func (m Model) handlePagination(listModel *list.Model, currentIndex *int) (Model, tea.Cmd) {
 	if listModel == nil {
 		return m, nil
 	}
@@ -710,7 +714,7 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 			return m, cmd
 		}
 		listModel := getListItemForMusicToChoose(&m, m.FocusedOn)
-		return m.handlePagination(listModel, m.FocusedOn == QueueList, nil)
+		return m.handlePagination(listModel, nil)
 	case "up", "k":
 		if m.MainViewMode == LyricsMode && m.FocusedOn == MainView {
 			var cmd tea.Cmd
@@ -798,10 +802,11 @@ func (m Model) handleKeyPress(msg tea.KeyMsg) (Model, tea.Cmd) {
 			m.MainViewMode = NormalMode
 			return m, nil
 		}
-		return m.getMusicLyrics(m.SelectedTrack)
+
+		return m.getMusicLyrics()
 	case "l":
-		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && m.SelectedTrack.Track.Track != nil {
-			trackID := m.SelectedTrack.Track.Track.VideoId
+		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil {
+			trackID := m.SelectedTrack.Track.VideoId
 			shouldRemove := m.SelectedTrack.isLiked
 			targetLikedState := !shouldRemove
 
@@ -927,14 +932,180 @@ func getNextPageItems(m *Model, paginationInfo *types.PaginationInfo) tea.Cmd {
 	}
 	return nil
 }
-func (m Model) getMusicLyrics(track *SelectedTrack) (Model, tea.Cmd) {
+func (m Model) getMusicLyrics() (Model, tea.Cmd) {
 	if m.MainViewMode == LyricsMode {
 		m.MainViewMode = NormalMode
 	} else {
 		m.MainViewMode = LyricsMode
 		m.FocusedOn = MainView
 	}
-	return m, nil
+
+	if m.SelectedTrack == nil || m.SelectedTrack.Track == nil ||
+		m.SelectedTrack.Track.DurationSeconds == 0 {
+		return m, nil
+	}
+
+	m.LyricsView.SetContent("  ⟳ Loading lyrics...")
+	selectedTrack := m.SelectedTrack
+	lyricsCmd := func() tea.Msg {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var backendResp *musicpb.GetLyricsResponse
+		lyricsResponse, err := m.YtMusicClient.GetLyrics(ctx, connect.NewRequest(&musicpb.GetLyricsRequest{
+			VideoId:    selectedTrack.Track.VideoId,
+			Timestamps: true,
+		}))
+		if err == nil && lyricsResponse != nil {
+			backendResp = lyricsResponse.Msg
+		}
+
+		if backendResp != nil && backendResp.HasTimestamps && len(backendResp.Lines) > 0 {
+			return types.LyricsMsg{LyricsResponse: backendResp}
+		}
+
+		lrclibResp := fetchLrclib(ctx, selectedTrack)
+
+		if lrclibResp != nil && lrclibResp.SyncedLyrics != "" {
+			lines := parseSyncedLyrics(lrclibResp.SyncedLyrics)
+			if len(lines) > 0 {
+				return types.LyricsMsg{
+					LyricsResponse: &musicpb.GetLyricsResponse{
+						HasTimestamps: true,
+						Lines:         lines,
+						Source:        "lrclib.net",
+					},
+				}
+			}
+		}
+
+		if backendResp != nil && backendResp.Lyrics != "" {
+			return types.LyricsMsg{LyricsResponse: backendResp}
+		}
+
+		if lrclibResp != nil && lrclibResp.PlainLyrics != "" {
+			return types.LyricsMsg{
+				LyricsResponse: &musicpb.GetLyricsResponse{
+					Lyrics: lrclibResp.PlainLyrics,
+					Source: "lrclib.net",
+				},
+			}
+		}
+
+		return types.LyricsMsg{LyricsResponse: nil, Err: err}
+	}
+
+	return m, lyricsCmd
+}
+
+type lrclibResponse struct {
+	SyncedLyrics string `json:"syncedLyrics"`
+	PlainLyrics  string `json:"plainLyrics"`
+}
+
+func fetchLrclib(ctx context.Context, track *SelectedTrack) *lrclibResponse {
+	params := url.Values{}
+	params.Add("track_name", track.Track.Title)
+	if track.Track.Album != "" {
+		params.Add("album_name", track.Track.Album)
+	}
+	if len(track.Track.Artists) > 0 {
+		params.Add("artist_name", track.Track.Artists[0].Name)
+	}
+	params.Add("duration", strconv.FormatInt(int64(track.Track.DurationSeconds), 10))
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://lrclib.net/api/get?"+params.Encode(), nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("User-Agent", "ytmusic-tui/1.0")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil
+	}
+
+	var result lrclibResponse
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil
+	}
+	return &result
+}
+
+func parseSyncedLyrics(synced string) []*musicpb.LyricLine {
+	var lines []*musicpb.LyricLine
+	for _, rawLine := range strings.Split(synced, "\n") {
+		rawLine = strings.TrimSpace(rawLine)
+		if rawLine == "" || !strings.HasPrefix(rawLine, "[") {
+			continue
+		}
+		closeBracket := strings.Index(rawLine, "]")
+		if closeBracket == -1 {
+			continue
+		}
+		timestamp := rawLine[1:closeBracket]
+		text := strings.TrimSpace(rawLine[closeBracket+1:])
+
+		ms, ok := parseLRCTimestamp(timestamp)
+		if !ok {
+			continue
+		}
+		lines = append(lines, &musicpb.LyricLine{
+			Text:      text,
+			StartTime: ms,
+		})
+	}
+	for i := 0; i < len(lines)-1; i++ {
+		lines[i].EndTime = lines[i+1].StartTime
+	}
+	return lines
+}
+
+func parseLRCTimestamp(ts string) (int32, bool) {
+	parts := strings.Split(ts, ":")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	minutes, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, false
+	}
+	secParts := strings.Split(parts[1], ".")
+	if len(secParts) != 2 {
+		return 0, false
+	}
+	seconds, err := strconv.Atoi(secParts[0])
+	if err != nil {
+		return 0, false
+	}
+	frac := secParts[1]
+	fracVal, err := strconv.Atoi(frac)
+	if err != nil {
+		return 0, false
+	}
+	var fracMs int
+	switch len(frac) {
+	case 1:
+		fracMs = fracVal * 100
+	case 2:
+		fracMs = fracVal * 10
+	case 3:
+		fracMs = fracVal
+	default:
+		fracMs = fracVal
+	}
+
+	return int32(minutes*60000 + seconds*1000 + fracMs), true
 }
 
 func (m *Model) toggleRightColumnMode() {
@@ -1033,7 +1204,7 @@ func (m Model) handleMusicChange(isForward bool) (Model, tea.Cmd) {
 
 		if !fromHistory && m.PlayedSeconds > 30 &&
 			m.SelectedTrack != nil && m.SelectedTrack.Track != nil {
-			appendToPlayHistory(&m, m.SelectedTrack.Track)
+			appendToPlayHistory(&m, &m.SelectedTrack.PlaylistTrackObject)
 		}
 	} else {
 		if len(m.PlayHistory) > 0 && m.PlayHistoryIndex > 0 {
@@ -1817,26 +1988,8 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 	m.playbackCancel = cancel
 	cmd := youtube.SearchAndDownloadMusic(playCtx, selectedMusic.Track.VideoId, m.CoreDepsPath)
 	m.CurrentLyrics = nil
-	m.LyricsView.SetContent("  ⟳ Loading lyrics...")
 
-	lyricsCmd := func() tea.Msg {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		lyricsResponse, err := m.YtMusicClient.GetLyrics(ctx, connect.NewRequest(&musicpb.GetLyricsRequest{
-			VideoId:    selectedMusic.Track.VideoId,
-			Timestamps: true,
-		}))
-		var lyricsResp *musicpb.GetLyricsResponse
-		if lyricsResponse != nil {
-			lyricsResp = lyricsResponse.Msg
-		}
-		return types.LyricsMsg{
-			LyricsResponse: lyricsResp,
-			Err:            err,
-		}
-	}
-
-	cmds = append(cmds, cmd, lyricsCmd)
+	cmds = append(cmds, cmd)
 	metadata := getMusicMetadata(MusicMetadata{
 		artistName: strings.Join(artistNames, ","),
 		length:     int64(selectedMusic.Track.DurationSeconds * 1000),
@@ -1865,8 +2018,8 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 	}
 	m.PlayedSeconds = 0
 	m.SelectedTrack = &SelectedTrack{
-		isLiked: false,
-		Track:   &selectedMusic,
+		isLiked:             false,
+		PlaylistTrackObject: selectedMusic,
 	}
 
 	cmds = append(cmds, m.SyncQueueList())
@@ -1965,8 +2118,8 @@ func SendLoadingCmd() tea.Cmd {
 
 func (m Model) getCurrentSelectedTrack() (string, string) {
 	if m.FocusedOn == Player {
-		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && m.SelectedTrack.Track.Track != nil {
-			return m.SelectedTrack.Track.Track.VideoId, m.SelectedTrack.Track.Track.Title
+		if m.SelectedTrack != nil && m.SelectedTrack.Track != nil {
+			return m.SelectedTrack.Track.VideoId, m.SelectedTrack.Track.Title
 		}
 		return "", ""
 	}
@@ -2000,8 +2153,8 @@ func (m Model) getCurrentSelectedTrack() (string, string) {
 		}
 	}
 
-	if m.SelectedTrack != nil && m.SelectedTrack.Track != nil && m.SelectedTrack.Track.Track != nil {
-		return m.SelectedTrack.Track.Track.VideoId, m.SelectedTrack.Track.Track.Title
+	if m.SelectedTrack != nil && m.SelectedTrack.Track != nil {
+		return m.SelectedTrack.Track.VideoId, m.SelectedTrack.Track.Title
 	}
 
 	return "", ""

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -582,6 +582,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.CurrentLyrics = nil
 			return m, nil
 		}
+		m.MainViewMode = LyricsMode
 		m.CurrentLyrics = msg.LyricsResponse
 		m.updateLyricsView()
 		return m, nil
@@ -947,19 +948,15 @@ type lrclibQuery struct {
 }
 
 func (m Model) getMusicLyrics() (Model, tea.Cmd) {
-	if m.MainViewMode == LyricsMode {
-		m.MainViewMode = NormalMode
-	} else {
-		m.MainViewMode = LyricsMode
-		m.FocusedOn = MainView
-	}
-
+	m.MainViewMode = LyricsMode
+	m.FocusedOn = MainView
 	if m.SelectedTrack == nil || m.SelectedTrack.Track == nil {
+		noLyricsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#71717A")).Italic(true)
+		m.LyricsView.SetContent(noLyricsStyle.Render("No track selected."))
 		return m, nil
 	}
 
 	m.LyricsView.SetContent("  ⟳ Loading lyrics...")
-
 	q := lrclibQuery{
 		videoID:     m.SelectedTrack.Track.VideoId,
 		trackName:   m.SelectedTrack.Track.Title,
@@ -2066,6 +2063,11 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 	}
 
 	cmds = append(cmds, m.SyncQueueList())
+	if m.MainViewMode == LyricsMode {
+		model, cmd := m.getMusicLyrics()
+		m = model
+		cmds = append(cmds, cmd)
+	}
 	return m, tea.Batch(cmds...)
 }
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1113,23 +1113,32 @@ func parseLRCTimestamp(ts string) (int32, bool) {
 	if len(parts) != 2 {
 		return 0, false
 	}
+	if strings.HasPrefix(parts[0], "-") {
+		return 0, false
+	}
 	minutes, err := strconv.Atoi(parts[0])
-	if err != nil {
+	if err != nil || minutes < 0 {
 		return 0, false
 	}
 	secParts := strings.Split(parts[1], ".")
 	if len(secParts) > 2 {
 		return 0, false
 	}
+	if strings.HasPrefix(secParts[0], "-") {
+		return 0, false
+	}
 	seconds, err := strconv.Atoi(secParts[0])
-	if err != nil {
+	if err != nil || seconds < 0 || seconds >= 60 {
 		return 0, false
 	}
 	var fracMs int
 	if len(secParts) == 2 {
 		frac := secParts[1]
+		if len(frac) == 0 || len(frac) > 3 || strings.HasPrefix(frac, "-") {
+			return 0, false
+		}
 		fracVal, err := strconv.Atoi(frac)
-		if err != nil {
+		if err != nil || fracVal < 0 {
 			return 0, false
 		}
 		switch len(frac) {
@@ -1138,8 +1147,6 @@ func parseLRCTimestamp(ts string) (int32, bool) {
 		case 2:
 			fracMs = fracVal * 10
 		case 3:
-			fracMs = fracVal
-		default:
 			fracMs = fracVal
 		}
 	}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -521,6 +521,10 @@ func TestParseLRCTimestamp(t *testing.T) {
 		{"invalid format", "invalid", 0, false},
 		{"invalid minutes", "xx:10.00", 0, false},
 		{"invalid seconds", "01:yy.00", 0, false},
+		{"negative minutes", "-01:10.00", 0, false},
+		{"seconds equal to 60", "01:60.00", 0, false},
+		{"seconds above 60", "01:75.00", 0, false},
+		{"fraction longer than 3 digits", "01:10.1234", 0, false},
 	}
 
 	for _, tt := range tests {

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -506,3 +506,55 @@ func TestUpdate_SongRelatedContent_ArtistSelection(t *testing.T) {
 		t.Error("cmd should not be nil when selecting related artist")
 	}
 }
+
+func TestParseLRCTimestamp(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantMs int32
+		wantOK bool
+	}{
+		{"1-digit fraction", "01:19.6", 79600, true},
+		{"2-digit fraction", "00:19.67", 19670, true},
+		{"3-digit fraction", "02:10.123", 130123, true},
+		{"no fraction", "01:30", 90000, true},
+		{"invalid format", "invalid", 0, false},
+		{"invalid minutes", "xx:10.00", 0, false},
+		{"invalid seconds", "01:yy.00", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMs, gotOK := parseLRCTimestamp(tt.input)
+			if gotOK != tt.wantOK {
+				t.Errorf("parseLRCTimestamp(%q) ok = %v, want %v", tt.input, gotOK, tt.wantOK)
+			}
+			if gotMs != tt.wantMs {
+				t.Errorf("parseLRCTimestamp(%q) ms = %d, want %d", tt.input, gotMs, tt.wantMs)
+			}
+		})
+	}
+}
+
+func TestParseSyncedLyrics(t *testing.T) {
+	synced := `[ar: Rick Astley]
+[ti: Never Gonna Give You Up]
+[00:19.67] Line 1
+[00:23.56] Line 2
+[00:27.92] Line 3
+`
+	lines := parseSyncedLyrics(synced)
+	if len(lines) != 3 {
+		t.Fatalf("parseSyncedLyrics lines length: want 3, got %d", len(lines))
+	}
+
+	if lines[0].Text != "Line 1" || lines[0].StartTime != 19670 || lines[0].EndTime != 23560 {
+		t.Errorf("Line 0: got text=%q, start=%d, end=%d", lines[0].Text, lines[0].StartTime, lines[0].EndTime)
+	}
+	if lines[1].Text != "Line 2" || lines[1].StartTime != 23560 || lines[1].EndTime != 27920 {
+		t.Errorf("Line 1: got text=%q, start=%d, end=%d", lines[1].Text, lines[1].StartTime, lines[1].EndTime)
+	}
+	if lines[2].Text != "Line 3" || lines[2].StartTime != 27920 || lines[2].EndTime != 0 {
+		t.Errorf("Line 2 (last): got text=%q, start=%d, end=%d (want end=0)", lines[2].Text, lines[2].StartTime, lines[2].EndTime)
+	}
+}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -83,7 +83,7 @@ func TestUpdate_PlayedSecondsUpdateMsg_NilTrack(t *testing.T) {
 func TestUpdate_PlayedSecondsUpdateMsg_UpdatesSeconds(t *testing.T) {
 	m := newTestModel()
 	m.SelectedTrack = &SelectedTrack{
-		Track: &types.PlaylistTrackObject{
+		PlaylistTrackObject: types.PlaylistTrackObject{
 			Track: &musicpb.Song{DurationSeconds: 200},
 		},
 	}
@@ -100,7 +100,7 @@ func TestUpdate_LikeUnlikeTrackMsg(t *testing.T) {
 	m := newTestModel()
 	m.SelectedTrack = &SelectedTrack{
 		isLiked: false,
-		Track: &types.PlaylistTrackObject{
+		PlaylistTrackObject: types.PlaylistTrackObject{
 			Track: &musicpb.Song{VideoId: "vid1"},
 		},
 	}
@@ -117,7 +117,7 @@ func TestUpdate_LikeUnlikeTrackMsg_DifferentID(t *testing.T) {
 	m := newTestModel()
 	m.SelectedTrack = &SelectedTrack{
 		isLiked: false,
-		Track: &types.PlaylistTrackObject{
+		PlaylistTrackObject: types.PlaylistTrackObject{
 			Track: &musicpb.Song{VideoId: "vid1"},
 		},
 	}
@@ -134,7 +134,7 @@ func TestUpdate_CheckUserSavedTrackMsg(t *testing.T) {
 	m := newTestModel()
 	m.SelectedTrack = &SelectedTrack{
 		isLiked: false,
-		Track: &types.PlaylistTrackObject{
+		PlaylistTrackObject: types.PlaylistTrackObject{
 			Track: &musicpb.Song{VideoId: "vid1"},
 		},
 	}
@@ -386,7 +386,7 @@ func TestUpdate_QueueList_MultiTrackRemovalAndPlayback(t *testing.T) {
 	updated.QueueList.Select(1)
 	resEnter, _ := updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	mPlayed := resEnter.(Model)
-	if mPlayed.SelectedTrack == nil || mPlayed.SelectedTrack.Track == nil || mPlayed.SelectedTrack.Track.Track.VideoId != "song1" {
+	if mPlayed.SelectedTrack == nil || mPlayed.SelectedTrack.Track == nil || mPlayed.SelectedTrack.Track.VideoId != "song1" {
 		t.Errorf("Played track: want song1, got %v", mPlayed.SelectedTrack)
 	}
 }
@@ -412,7 +412,7 @@ func TestUpdate_QueueList_ContextItemSelection(t *testing.T) {
 	if mPlayed.PlaylistContextIndex != 1 {
 		t.Errorf("PlaylistContextIndex: want 1 for ctx2, got %d", mPlayed.PlaylistContextIndex)
 	}
-	if mPlayed.SelectedTrack == nil || mPlayed.SelectedTrack.Track.Track.VideoId != "ctx2" {
+	if mPlayed.SelectedTrack == nil || mPlayed.SelectedTrack.Track.VideoId != "ctx2" {
 		t.Errorf("Played track: want ctx2, got %v", mPlayed.SelectedTrack)
 	}
 }
@@ -421,7 +421,7 @@ func TestUpdate_PlayerActions(t *testing.T) {
 	m := newTestModel()
 	m.FocusedOn = Player
 	m.SelectedTrack = &SelectedTrack{
-		Track: &types.PlaylistTrackObject{
+		PlaylistTrackObject: types.PlaylistTrackObject{
 			Track: &musicpb.Song{VideoId: "v1", Title: "Test Song"},
 		},
 	}

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -245,18 +244,6 @@ type StreamAndDuration struct {
 	HTTPHeaders map[string]string
 }
 
-func logYtDlpErr(err error) {
-	if err == nil {
-		return
-	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-		slog.Error("yt-dlp error", "stderr", string(exitErr.Stderr), "err", err)
-	} else {
-		slog.Error(err.Error())
-	}
-}
-
 func GetStreamURLAndDuration(ctx context.Context, videoID string, ytdlpPath string) (*StreamAndDuration, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
 	defer cancel()
@@ -272,25 +259,27 @@ func GetStreamURLAndDuration(ctx context.Context, videoID string, ytdlpPath stri
 
 	cmd, err := command.ExecCommand(timeoutCtx, ytdlpPath, args...)
 	if err != nil {
-		logYtDlpErr(err)
+		slog.Error(err.Error())
 		return nil, err
 	}
 	outBytes, err := cmd.Output()
 	if err != nil {
-		logYtDlpErr(err)
+		slog.Error(err.Error())
 		fallbackArgs := []string{"-j", "--no-warnings", "-f", "ba[acodec=opus][tbr<=300]/ba[tbr<=300]/ba"}
 		if cookiePath != "" {
 			fallbackArgs = append(fallbackArgs, "--cookies", cookiePath)
 		}
 		fallbackArgs = append(fallbackArgs, targetURL)
-		cmd, err = command.ExecCommand(timeoutCtx, ytdlpPath, fallbackArgs...)
+		fallbackCtx, fallbackCancel := context.WithTimeout(ctx, 45*time.Second)
+		defer fallbackCancel()
+		cmd, err = command.ExecCommand(fallbackCtx, ytdlpPath, fallbackArgs...)
 		if err != nil {
-			logYtDlpErr(err)
+			slog.Error(err.Error())
 			return nil, err
 		}
 		outBytes, err = cmd.Output()
 		if err != nil {
-			logYtDlpErr(err)
+			slog.Error(err.Error())
 			return nil, fmt.Errorf("failed to fetch metadata using yt-dlp: %w", err)
 		}
 	}
@@ -301,13 +290,13 @@ func GetStreamURLAndDuration(ctx context.Context, videoID string, ytdlpPath stri
 		HTTPHeaders map[string]string `json:"http_headers"`
 	}
 	if err := json.Unmarshal(outBytes, &data); err != nil {
-		logYtDlpErr(err)
+		slog.Error(err.Error())
 		return nil, fmt.Errorf("failed to parse yt-dlp metadata: %w", err)
 	}
 
 	if data.URL == "" {
 		err := fmt.Errorf("empty stream url returned by yt-dlp for video: %s", videoID)
-		logYtDlpErr(err)
+		slog.Error(err.Error())
 		return nil, err
 	}
 

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -268,7 +268,7 @@ func GetStreamURLAndDuration(ctx context.Context, videoID string, ytdlpPath stri
 	if cookiePath != "" {
 		args = append(args, "--cookies", cookiePath)
 	}
-	args = append(args, "-f", "bestaudio[abr>=120][abr<=250]/bestaudio/best", targetURL)
+	args = append(args, "-f", "ba[acodec=opus][tbr<=300]/ba[tbr<=300]/ba", targetURL)
 
 	cmd, err := command.ExecCommand(timeoutCtx, ytdlpPath, args...)
 	if err != nil {
@@ -278,7 +278,7 @@ func GetStreamURLAndDuration(ctx context.Context, videoID string, ytdlpPath stri
 	outBytes, err := cmd.Output()
 	if err != nil {
 		logYtDlpErr(err)
-		fallbackArgs := []string{"-j", "--no-warnings"}
+		fallbackArgs := []string{"-j", "--no-warnings", "-f", "ba[acodec=opus][tbr<=300]/ba[tbr<=300]/ba"}
 		if cookiePath != "" {
 			fallbackArgs = append(fallbackArgs, "--cookies", cookiePath)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved lyrics loading, including timestamped and plain lyrics.
  * Added synchronized lyrics with accurate line timing and parsing support.
  * Added a fallback lyrics source when lyrics are unavailable from the primary service.
  * Added a visible loading state while lyrics are being retrieved.

* **Bug Fixes**
  * Improved track selection, playback, queue history, liking, and now-playing behavior.
  * Improved lyric handling when no track is selected or track information is incomplete.
  * Improved YouTube audio stream selection for more consistent playback quality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->