### PR TITLE
fix: artist name is not shown on media control,

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ Before starting, ensure you have the following installed:
 - **Protobuf Compiler (`protoc`)**: Required if modifying `.proto` files
   - Go plugins: `go install google.golang.org/protobuf/cmd/protoc-gen-go@latest` and `go install connectrpc.com/connect/cmd/protoc-gen-connect-go@latest`
 - **System Dependencies**:
-  - **`yt-dlp`**: Required for extracting and fetching YouTube Music audio stream URLs
-  - **`ffmpeg`**: Required for audio stream decoding and playback
+  - **[yt-dlp](https://github.com/yt-dlp/yt-dlp)**: Required for extracting and fetching YouTube Music audio stream URLs
+  - **[ffmpeg](https://ffmpeg.org/)**: Required for audio stream decoding and playback
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,9 +6,10 @@ Before building `ytmusic-tui` from source, ensure you have the following install
 
 - **[Go](https://go.dev/dl/)** (v1.26 or higher)
 - **[Python](https://www.python.org/downloads/)** (v3.13 or higher) & **[uv](https://docs.astral.sh/uv/)** (recommended Python package manager)
-- **`yt-dlp`** (required for extracting YouTube Music audio stream URLs)
-- **`ffmpeg`** (required for audio stream decoding and playback)
----
+
+- **System Dependencies**:
+  - **[yt-dlp](https://github.com/yt-dlp/yt-dlp)**: Required for extracting and fetching YouTube Music audio stream URLs
+  - **[ffmpeg](https://ffmpeg.org/)**: Required for audio stream decoding and playback
 
 ## Installation Steps
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -36,7 +36,8 @@ func getMusicMetadata(music MusicMetadata) map[string]any {
 		"mpris:trackid": "/org/mpris/MediaPlayer2/" + music.title,
 		"xesam:title":   music.title,
 		"xesam:artist":  music.artistName,
-		"xesam:album":   dbus.MakeVariant(music.albumName),
+		"xesam:length":  music.length,
+		"xesam:album":   music.albumName,
 	}
 	return metadata
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -25,17 +25,18 @@ import (
 )
 
 type MusicMetadata struct {
-	artistName string
+	artistName []string
 	title      string
 	length     int64
+	albumName  string
 }
 
 func getMusicMetadata(music MusicMetadata) map[string]any {
 	var metadata = map[string]any{
 		"mpris:trackid": "/org/mpris/MediaPlayer2/" + music.title,
-		"mpris:length":  music.length,
 		"xesam:title":   music.title,
 		"xesam:artist":  music.artistName,
+		"xesam:album":   dbus.MakeVariant(music.albumName),
 	}
 	return metadata
 }
@@ -429,6 +430,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			model, cmd := m.getSearchResultModel(msg.Result)
 			m = model
 			m.IsSearchLoading = false
+			m.Search.Blur()
 			return m, cmd
 		}
 	case types.HomePageResponseMsg:
@@ -2038,9 +2040,10 @@ func (m Model) PlaySelectedMusic(selectedMusic types.PlaylistTrackObject) (Model
 
 	cmds = append(cmds, cmd)
 	metadata := getMusicMetadata(MusicMetadata{
-		artistName: strings.Join(artistNames, ","),
+		artistName: artistNames,
 		length:     int64(selectedMusic.Track.DurationSeconds * 1000),
 		title:      selectedMusic.Track.Title,
+		albumName:  selectedMusic.Track.Album,
 	})
 
 	if m.DBusConn != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Music metadata now supports multiple artists and album names for more complete track information.
  - Search input automatically loses focus after results are displayed, improving keyboard and playback interaction.

- **Documentation**
  - Clarified the roles of `yt-dlp` and `ffmpeg` in installation prerequisites.
  - Added links to the official websites for required system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->