### PR TITLE
fix: clear old queue items before add new items"

### DIFF
--- a/grpc_server/main.py
+++ b/grpc_server/main.py
@@ -102,7 +102,7 @@ class Service(MusicService):
             try:
                 songs_data = await asyncio.to_thread(yt.get_liked_songs, limit=5)
                 tracks = songs_data.get("tracks")
-                if isinstance(tracks, list) and len(tracks) > 0:
+                if isinstance(tracks, list) and len(tracks) > 0:  # pyright: ignore[reportUnknownArgumentType]
                     return music_pb2.LoginResponse(authenticated=True, error="", user_name="")
             except Exception as e:
                 if err is None:

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -144,7 +144,7 @@ func (m Model) Init() tea.Cmd {
 			Err:      nil,
 		}
 	}
-	return tea.Batch(m.Alert.Init(), SendLoadingCmd(), homePageFeed)
+	return tea.Batch(m.Alert.Init(), SendLoadingCmd(), homePageFeed, tea.SetWindowTitle("YTmusic-tui"))
 }
 
 func renderBreadcrumbs(items []types.Breadcrumb) string {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -68,6 +68,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		for _, song := range msg.WatchPlaylistItems.Tracks {
+			if song.VideoId == currentlyPlayingTrackID {
+				continue
+			}
 			m.Queue.AddTrack(&types.PlaylistTrackObject{
 				Track: song,
 			})
@@ -1773,8 +1776,9 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 				Err:                err,
 			}
 		}
+		m.Queue.Clear()
 		m, cmd := m.playStandaloneTrack(playlistTrack)
-		return m, tea.Batch(cmd, watchPlaylistCmd)
+		return m, tea.Batch(cmd, tea.Sequence(m.SyncQueueList(), watchPlaylistCmd))
 
 	case types.SearchResultPlaylistItem:
 		if selectedItem.SearchResultPlaylist != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The terminal window now displays the application title “YTmusic-tui.”

* **Bug Fixes**
  * Prevented the currently playing track from being added again when handling watched playlist items.
  * Starting a song from search results now clears the previous queue and updates the queue display before loading related items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->