### PR TITLE
fix: dont add watch playlist items into main queue

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -376,6 +376,7 @@ func runRoot(cmd *cobra.Command, serverURL string) error {
 	if ins != nil {
 		ins.Conn.Close()
 	}
+
 	return nil
 }
 

--- a/grpc_server/main.py
+++ b/grpc_server/main.py
@@ -234,7 +234,6 @@ class Service(MusicService):
                 ) or {}
         response = music_pb2.GetWatchPlaylistItemsResponse(
         )
-
         for track in (playlist_data.get('tracks') or []):
             isAvailable = track.get('isAvailable')
             if isAvailable or isAvailable is None:

--- a/grpc_server/src/client/types.py
+++ b/grpc_server/src/client/types.py
@@ -52,6 +52,7 @@ class YTLikedSongsResponse(TypedDict, total=False):
     tracks: list[YTSong]
 
 class YTWatchPlaylistResponse(TypedDict, total=False):
+    playlistId:str
     tracks: list[YTSong]    
 
 

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -308,8 +308,12 @@ func (m *Model) SyncQueueList() tea.Cmd {
 
 		limit := len(m.PlaybackContext)
 		startIdx := m.PlaylistContextIndex
-		if m.SelectedTrack != nil && m.SelectedTrack.Track.VideoId == m.PlaybackContext[startIdx].Track.VideoId {
+		if startIdx >= 0 && startIdx < limit && m.PlaybackContext[startIdx] != nil &&
+			m.SelectedTrack != nil && m.SelectedTrack.Track.VideoId == m.PlaybackContext[startIdx].Track.VideoId {
 			startIdx++
+		}
+		if startIdx < 0 || startIdx >= limit {
+			startIdx = 0
 		}
 		for idx := startIdx; idx < limit; idx++ {
 			if m.PlaybackContext[idx] != nil {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -37,14 +37,9 @@ type MainViewMode string
 
 const (
 	SearchResultMode MainViewMode = "SEARCH_RESULT_MODE"
-	//currently im showing the search result in main area which is the center one
-	//let's say the user searches for a song or playlist and sees the result and he chose the first result
-	//at this time the previous are gone b/c i was sharing  this main new to show items in playlist and the search result
-	// so by adding this MainViewMode we can switch b/c modes so that we keep the result in memory
-	// meaning we can switch b/n search result and normal mode
-	NormalMode   MainViewMode = "NORMAL_MODE"
-	LyricsMode   MainViewMode = "LYRICS_MODE"
-	HomePageMode MainViewMode = "HOME_PAGE_MODE"
+	NormalMode       MainViewMode = "NORMAL_MODE"
+	LyricsMode       MainViewMode = "LYRICS_MODE"
+	HomePageMode     MainViewMode = "HOME_PAGE_MODE"
 )
 
 type HomePageViewMode int
@@ -103,23 +98,18 @@ type Model struct {
 	PlayHistoryIndex     int
 	YtMusicClient        genconnect.MusicServiceClient
 	DBusConn             *Instance
-	//actually i need this b/c if user searches and selects playlist or artist
-	//at that time when he selects artist or playlist the search were hidden from mainView
-	//so that if search again we can show the previous result by comparing the query
-	// TODO: find a better way than this looks very ugly
-	SearchQuery string
-	// SearchResult                             *SpotifySearchResult
-	IsSearchLoading  bool
-	SearchResult     list.Model
-	PaginationInfo   *types.PaginationInfo
-	IsOnPagination   bool
-	CoreDepsPath     *youtube.CoreDepsPath
-	HomePageData     *musicpb.GetHomePageResponse
-	HomePageList     list.Model
-	HomePageViewMode HomePageViewMode
-	RelatedList      list.Model
-	RightColumnMode  RightColumnMode
-	CurrentLyrics    *musicpb.GetLyricsResponse
+	SearchQuery          string
+	IsSearchLoading      bool
+	SearchResult         list.Model
+	PaginationInfo       *types.PaginationInfo
+	IsOnPagination       bool
+	CoreDepsPath         *youtube.CoreDepsPath
+	HomePageData         *musicpb.GetHomePageResponse
+	HomePageList         list.Model
+	HomePageViewMode     HomePageViewMode
+	RelatedList          list.Model
+	RightColumnMode      RightColumnMode
+	CurrentLyrics        *musicpb.GetLyricsResponse
 }
 
 type Instance struct {
@@ -309,10 +299,12 @@ func (m *Model) SyncQueueList() tea.Cmd {
 
 	if len(m.PlaybackContext) > 0 {
 		contextName := m.PlaybackContextName
-		if contextName == "" {
-			contextName = "Playlist"
+		if contextName != "" {
+			items = append(items, types.HomePageSectionItem{SectionTitle: "Next from " + contextName})
 		}
-		items = append(items, types.HomePageSectionItem{SectionTitle: "Next from " + contextName})
+		if contextName == "" {
+			items = append(items, types.HomePageSectionItem{SectionTitle: "Next Up"})
+		}
 
 		n := len(m.PlaybackContext)
 		startIdx := m.PlaylistContextIndex

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -306,15 +306,12 @@ func (m *Model) SyncQueueList() tea.Cmd {
 			items = append(items, types.HomePageSectionItem{SectionTitle: "Next Up"})
 		}
 
-		n := len(m.PlaybackContext)
+		limit := len(m.PlaybackContext)
 		startIdx := m.PlaylistContextIndex
-		limit := n
-		if m.SelectedTrack != nil {
+		if m.SelectedTrack != nil && m.SelectedTrack.Track.VideoId == m.PlaybackContext[startIdx].Track.VideoId {
 			startIdx++
-			limit = n - 1
 		}
-		for i := 0; i < limit; i++ {
-			idx := (startIdx + i) % n
+		for idx := startIdx; idx < limit; idx++ {
 			if m.PlaybackContext[idx] != nil {
 				items = append(items, *m.PlaybackContext[idx])
 			}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1777,9 +1777,8 @@ func (m Model) handleMainViewOrQueueEnter() (Model, tea.Cmd) {
 				Err:                err,
 			}
 		}
-		m.Queue.Clear()
 		m, cmd := m.playStandaloneTrack(playlistTrack)
-		return m, tea.Batch(cmd, tea.Sequence(m.SyncQueueList(), watchPlaylistCmd))
+		return m, tea.Batch(cmd, watchPlaylistCmd)
 
 	case types.SearchResultPlaylistItem:
 		if selectedItem.SearchResultPlaylist != nil {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1269,7 +1269,14 @@ func (m Model) handleMusicChange(isForward bool) (Model, tea.Cmd) {
 			track = m.PlayHistory[m.PlayHistoryIndex]
 			fromHistory = true
 		} else if len(m.PlaybackContext) > 0 {
-			m.PlaylistContextIndex = (m.PlaylistContextIndex + 1) % len(m.PlaybackContext)
+			idx := m.PlaylistContextIndex
+			if idx >= 0 && idx < len(m.PlaybackContext) &&
+				m.SelectedTrack != nil && m.SelectedTrack.Track != nil &&
+				m.PlaybackContext[idx].Track != nil &&
+				m.SelectedTrack.Track.VideoId == m.PlaybackContext[idx].Track.VideoId {
+				idx = (idx + 1) % len(m.PlaybackContext)
+			}
+			m.PlaylistContextIndex = idx
 			track = m.PlaybackContext[m.PlaylistContextIndex]
 		} else if len(m.PlayHistory) > 0 {
 			m.PlayHistoryIndex = 0
@@ -1560,7 +1567,13 @@ func (m Model) playTrackFromList(track types.PlaylistTrackObject) (Model, tea.Cm
 		contextName = "Playlist"
 	}
 
-	selectedIdx := m.SelectedPlayListItems.Index()
+	selectedIdx := 0
+	for i, ct := range contextTracks {
+		if ct.Track != nil && ct.Track.VideoId == track.Track.VideoId {
+			selectedIdx = i
+			break
+		}
+	}
 	m.SetPlaybackContext(contextTracks, contextName, selectedIdx)
 
 	return m.PlaySelectedMusic(track)
@@ -1618,7 +1631,13 @@ func (m Model) handleHomePageEnter() (Model, tea.Cmd) {
 			if contextName == "" {
 				contextName = "Home"
 			}
-			selectedIdx := m.HomePageList.Index()
+			selectedIdx := 0
+			for i, ct := range contextTracks {
+				if ct.Track != nil && ct.Track.VideoId == trackID {
+					selectedIdx = i
+					break
+				}
+			}
 			if len(contextTracks) > 0 {
 				m.SetPlaybackContext(contextTracks, contextName, selectedIdx)
 			}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -71,10 +71,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if song.VideoId == currentlyPlayingTrackID {
 				continue
 			}
-			m.Queue.AddTrack(&types.PlaylistTrackObject{
+			m.PlaybackContext = append(m.PlaybackContext, &types.PlaylistTrackObject{
 				Track: song,
 			})
 		}
+		m.PlaybackContextName = ""
 		return m, m.SyncQueueList()
 	case types.CreatePlaylistMsg:
 		cmd := func() tea.Msg {

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -1566,12 +1566,25 @@ func (m Model) playTrackFromList(track types.PlaylistTrackObject) (Model, tea.Cm
 	if contextName == "" {
 		contextName = "Playlist"
 	}
-
+	sourceIdx := m.SelectedPlayListItems.Index()
+	occurrence := 0
+	for i, item := range playlistItems {
+		if pt, ok := item.(types.PlaylistTrackObject); ok && pt.Track != nil && pt.Track.VideoId == track.Track.VideoId {
+			occurrence++
+		}
+		if i == sourceIdx {
+			break
+		}
+	}
 	selectedIdx := 0
+	seen := 0
 	for i, ct := range contextTracks {
 		if ct.Track != nil && ct.Track.VideoId == track.Track.VideoId {
-			selectedIdx = i
-			break
+			seen++
+			if seen == occurrence {
+				selectedIdx = i
+				break
+			}
 		}
 	}
 	m.SetPlaybackContext(contextTracks, contextName, selectedIdx)
@@ -1631,11 +1644,25 @@ func (m Model) handleHomePageEnter() (Model, tea.Cmd) {
 			if contextName == "" {
 				contextName = "Home"
 			}
+			sourceIdx := m.HomePageList.Index()
+			occurrence := 0
+			for i, hpItem := range m.HomePageList.Items() {
+				if ci, ok := hpItem.(types.HomePageContentItem); ok && ci.VideoID == trackID {
+					occurrence++
+				}
+				if i == sourceIdx {
+					break
+				}
+			}
 			selectedIdx := 0
+			seen := 0
 			for i, ct := range contextTracks {
 				if ct.Track != nil && ct.Track.VideoId == trackID {
-					selectedIdx = i
-					break
+					seen++
+					if seen == occurrence {
+						selectedIdx = i
+						break
+					}
 				}
 			}
 			if len(contextTracks) > 0 {

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -615,11 +615,11 @@ func TestUpdate_WatchPlaylistItemsMsg_AddsTracks(t *testing.T) {
 	result, _ := m.Update(msg)
 	updated := result.(Model)
 
-	if updated.Queue.Len() != 3 {
-		t.Fatalf("Queue items: want 3, got %d", updated.Queue.Len())
+	if len(updated.PlaybackContext) != 3 {
+		t.Fatalf("Queue items: want 3, got %d", len(updated.PlaybackContext))
 	}
 
-	tracks := updated.Queue.AllTracks()
+	tracks := updated.PlaybackContext
 	expectedIDs := []string{"watch1", "watch2", "watch3"}
 	for i, id := range expectedIDs {
 		if tracks[i].Track.VideoId != id {
@@ -677,8 +677,8 @@ func TestUpdate_WatchPlaylistItemsMsg_NoSelectedTrack(t *testing.T) {
 	result, _ := m.Update(msg)
 	updated := result.(Model)
 
-	if updated.Queue.Len() != 2 {
-		t.Errorf("Queue items: want 2 when no selected track, got %d", updated.Queue.Len())
+	if len(updated.PlaybackContext) != 2 {
+		t.Errorf("Queue items: want 2 when no selected track, got %d", len(updated.PlaybackContext))
 	}
 }
 
@@ -717,9 +717,11 @@ func TestUpdate_WatchPlaylistItemsMsg_AppendsToExistingQueue(t *testing.T) {
 
 	existing := types.PlaylistTrackObject{Track: &musicpb.Song{VideoId: "existing1", Title: "Existing Track"}}
 	m.Queue.AddTrack(&existing)
+	m.SyncQueueList()
 
 	watchResp := &musicpb.GetWatchPlaylistItemsResponse{
 		Tracks: []*musicpb.Song{
+			{VideoId: "current-video", Title: "Current Song"},
 			{VideoId: "watch1", Title: "Watch Track 1"},
 			{VideoId: "watch2", Title: "Watch Track 2"},
 		},
@@ -732,12 +734,20 @@ func TestUpdate_WatchPlaylistItemsMsg_AppendsToExistingQueue(t *testing.T) {
 
 	result, _ := m.Update(msg)
 	updated := result.(Model)
+	m.SyncQueueList()
 
-	if updated.Queue.Len() != 3 {
-		t.Fatalf("Queue items: want 3 (1 existing + 2 new), got %d", updated.Queue.Len())
+	items := updated.QueueList.Items()
+	var tracks []*types.PlaylistTrackObject
+	for _, item := range items {
+		if track, ok := item.(types.PlaylistTrackObject); ok {
+			tracks = append(tracks, &track)
+		}
 	}
 
-	tracks := updated.Queue.AllTracks()
+	if len(tracks) != 3 {
+		t.Fatalf("Queue items: want 3 (1 existing + 2 new), got %d", len(tracks))
+	}
+
 	if tracks[0].Track.VideoId != "existing1" {
 		t.Errorf("Track 0: want existing1, got %q", tracks[0].Track.VideoId)
 	}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -758,3 +758,77 @@ func TestUpdate_WatchPlaylistItemsMsg_AppendsToExistingQueue(t *testing.T) {
 		t.Errorf("Track 2: want watch2, got %q", tracks[2].Track.VideoId)
 	}
 }
+
+func TestUpdate_WatchPlaylistItems_EmptyContext_FirstTrackSelected(t *testing.T) {
+	m := newTestModel()
+	m.PlaybackContext = nil
+	m.PlaylistContextIndex = 0
+	m.SelectedTrack = &SelectedTrack{
+		PlaylistTrackObject: types.PlaylistTrackObject{
+			Track: &musicpb.Song{VideoId: "current", Title: "Current Song"},
+		},
+	}
+
+	msg := types.WatchPlaylistItemsMsg{
+		SourceID: "current",
+		WatchPlaylistItems: &musicpb.GetWatchPlaylistItemsResponse{
+			Tracks: []*musicpb.Song{
+				{VideoId: "current", Title: "Current Song"},
+				{VideoId: "next1", Title: "Next 1"},
+				{VideoId: "next2", Title: "Next 2"},
+				{VideoId: "next3", Title: "Next 3"},
+			},
+		},
+	}
+
+	result, _ := m.Update(msg)
+	updated := result.(Model)
+
+	if len(updated.PlaybackContext) != 3 {
+		t.Fatalf("PlaybackContext length: want 3, got %d", len(updated.PlaybackContext))
+	}
+
+	if updated.PlaylistContextIndex != 0 {
+		t.Errorf("PlaylistContextIndex: want 0, got %d", updated.PlaylistContextIndex)
+	}
+	if updated.PlaybackContext[0].Track.VideoId != "next1" {
+		t.Errorf("First next track: want next1, got %s", updated.PlaybackContext[0].Track.VideoId)
+	}
+}
+
+func TestUpdate_HomePageEnter_NonVideoBeforePlayable_CorrectIndex(t *testing.T) {
+	m := newTestModel()
+	m.FocusedOn = MainView
+	m.MainViewMode = HomePageMode
+	m.HomePageViewMode = HomePageContentView
+
+	dims := CalculateLayoutDimensions(&m)
+	d := CustomDelegate{Model: &m}
+	items := []list.Item{
+		types.HomePageContentItem{ItemTitle: "Some Album", BrowseID: "MPRE_album1", ContentType: "album", VideoID: ""},
+		types.HomePageContentItem{ItemTitle: "Song A", VideoID: "vidA", Artists: []*musicpb.Artist{{Name: "Artist A"}}},
+		types.HomePageContentItem{ItemTitle: "Song B", VideoID: "vidB", Artists: []*musicpb.Artist{{Name: "Artist B"}}},
+	}
+	m.HomePageList = list.New(items, d, dims.MainWidth, dims.ContentHeight)
+	m.HomePageList.Title = "Test Section"
+
+	m.HomePageList.Select(1)
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := result.(Model)
+
+	if len(updated.PlaybackContext) != 2 {
+		t.Fatalf("PlaybackContext length: want 2, got %d", len(updated.PlaybackContext))
+	}
+
+	if updated.PlaylistContextIndex != 0 {
+		t.Errorf("PlaylistContextIndex: want 0 (filtered position of Song A), got %d", updated.PlaylistContextIndex)
+	}
+
+	if updated.PlaybackContext[0].Track.VideoId != "vidA" {
+		t.Errorf("PlaybackContext[0]: want vidA, got %s", updated.PlaybackContext[0].Track.VideoId)
+	}
+	if updated.PlaybackContext[1].Track.VideoId != "vidB" {
+		t.Errorf("PlaybackContext[1]: want vidB, got %s", updated.PlaybackContext[1].Track.VideoId)
+	}
+}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -832,3 +832,70 @@ func TestUpdate_HomePageEnter_NonVideoBeforePlayable_CorrectIndex(t *testing.T) 
 		t.Errorf("PlaybackContext[1]: want vidB, got %s", updated.PlaybackContext[1].Track.VideoId)
 	}
 }
+
+func TestUpdate_PlayTrackFromList_DuplicateVideoId(t *testing.T) {
+	m := newTestModel()
+	m.FocusedOn = MainView
+	m.MainViewMode = NormalMode
+
+	dims := CalculateLayoutDimensions(&m)
+	d := CustomDelegate{Model: &m}
+	items := []list.Item{
+		types.PlaylistTrackObject{Track: &musicpb.Song{VideoId: "songA", Title: "Song A (1st)"}},
+		types.PlaylistTrackObject{Track: &musicpb.Song{VideoId: "songB", Title: "Song B"}},
+		types.PlaylistTrackObject{Track: &musicpb.Song{VideoId: "songA", Title: "Song A (2nd)"}},
+		types.PlaylistTrackObject{Track: &musicpb.Song{VideoId: "songC", Title: "Song C"}},
+	}
+	m.SelectedPlayListItems = list.New(items, d, dims.MainWidth, dims.ContentHeight)
+	m.SelectedPlayListItems.Title = "Test Playlist"
+
+	m.SelectedPlayListItems.Select(2)
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := result.(Model)
+
+	if len(updated.PlaybackContext) != 4 {
+		t.Fatalf("PlaybackContext length: want 4, got %d", len(updated.PlaybackContext))
+	}
+	if updated.PlaylistContextIndex != 2 {
+		t.Errorf("PlaylistContextIndex: want 2 (2nd occurrence of songA), got %d", updated.PlaylistContextIndex)
+	}
+
+	if updated.PlaybackContext[3].Track.VideoId != "songC" {
+		t.Errorf("Next track after 2nd songA: want songC at index 3, got %s", updated.PlaybackContext[3].Track.VideoId)
+	}
+}
+
+func TestUpdate_HomePageEnter_DuplicateVideoId(t *testing.T) {
+	m := newTestModel()
+	m.FocusedOn = MainView
+	m.MainViewMode = HomePageMode
+	m.HomePageViewMode = HomePageContentView
+
+	dims := CalculateLayoutDimensions(&m)
+	d := CustomDelegate{Model: &m}
+	items := []list.Item{
+		types.HomePageContentItem{ItemTitle: "Song X (1st)", VideoID: "vidX"},
+		types.HomePageContentItem{ItemTitle: "Song Y", VideoID: "vidY"},
+		types.HomePageContentItem{ItemTitle: "Song X (2nd)", VideoID: "vidX"},
+		types.HomePageContentItem{ItemTitle: "Song Z", VideoID: "vidZ"},
+	}
+	m.HomePageList = list.New(items, d, dims.MainWidth, dims.ContentHeight)
+	m.HomePageList.Title = "Test Section"
+
+	m.HomePageList.Select(2)
+
+	result, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := result.(Model)
+
+	if len(updated.PlaybackContext) != 4 {
+		t.Fatalf("PlaybackContext length: want 4, got %d", len(updated.PlaybackContext))
+	}
+	if updated.PlaylistContextIndex != 2 {
+		t.Errorf("PlaylistContextIndex: want 2 (2nd occurrence of vidX), got %d", updated.PlaylistContextIndex)
+	}
+
+	if updated.PlaybackContext[3].Track.VideoId != "vidZ" {
+		t.Errorf("Next track after 2nd vidX: want vidZ at index 3, got %s", updated.PlaybackContext[3].Track.VideoId)
+	}
+}

--- a/internal/youtube/youtube.go
+++ b/internal/youtube/youtube.go
@@ -216,7 +216,6 @@ func SearchAndDownloadMusic(
 				_ = pr.Close()
 				if player != nil {
 					player.Pause()
-					player.Close()
 				}
 				if ffStderr != nil {
 					_ = ffStderr.Close()

--- a/proto/music.proto
+++ b/proto/music.proto
@@ -196,7 +196,8 @@ message GetWatchPlaylistItemsRequest {
 }
 
 message GetWatchPlaylistItemsResponse {
-  repeated Song tracks = 7;
+  string playlist_id = 1;
+  repeated Song tracks = 2;
 }
 
 message GetPlaylistItemsResponse {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watch-playlist responses now include playlist identification.
  * Watch-playlist tracks are added to the current playback context.
* **Improvements**
  * Empty playback contexts are labeled “Next Up” for clearer queue navigation.
  * Queue navigation now follows tracks more predictably.
  * Playing search results preserves the existing queue.
  * Playlist and homepage playback now selects the intended track more reliably.
* **Bug Fixes**
  * Improved player cleanup behavior when playback ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->